### PR TITLE
fix:#277 ItemObserver@updatedメソッドを修正し、image1カラムが変更された場合はold_valueとnew…

### DIFF
--- a/app/Observers/ItemObserver.php
+++ b/app/Observers/ItemObserver.php
@@ -44,6 +44,11 @@ class ItemObserver
         foreach ($changes as $field => $newValue) {
             $oldValue = $item->getOriginal($field);
 
+            if ($field == 'image1') {
+                $oldValue = null;
+                $newValue = null;
+            }
+
             Edithistory::create([
                 'edit_mode' => $edit_mode,
                 'operation_type' => 'update',


### PR DESCRIPTION
…_valueにnullが入るようif文を追加した