### PR TITLE
fix:#266 スマホ画面のレスポンシブナビリンクの通知リンクの表示権限をstaff(role=5)以上に変更

### DIFF
--- a/resources/js/Layouts/AuthenticatedLayout.vue
+++ b/resources/js/Layouts/AuthenticatedLayout.vue
@@ -166,10 +166,10 @@ const profileImageUrl: ComputedRef<string> = computed(() =>{
                         <ResponsiveNavLink :href="route('item_requests.index')" :active="route().current('item_requests.index')">
                             リクエスト
                         </ResponsiveNavLink>
-                        <ResponsiveNavLink :href="route('notifications.index')" :active="route().current('notifications.index')">
+                        <ResponsiveNavLink v-if="page.props.auth.user_role <= 5" :href="route('notifications.index')" :active="route().current('notifications.index')">
                             <div class="flex">
                                 <div class="mr-2">通知</div>
-                                <BellNotification :isLink="false" v-if="page.props.auth.user_role <= 5" class="flex" />
+                                <BellNotification :isLink="false" class="flex" />
                             </div>
                         </ResponsiveNavLink>
                     </div>
@@ -192,7 +192,7 @@ const profileImageUrl: ComputedRef<string> = computed(() =>{
                                  <!-- Profile  -->
                             </ResponsiveNavLink>
                             <ResponsiveNavLink :href="route('logout')" method="post" as="button">
-                                Log Out
+                                ログアウト
                             </ResponsiveNavLink>
                         </div>
                     </div>


### PR DESCRIPTION
## 目的

ユーザー権限ではアクセスできないスマホ画面のナビリンクの通知リンクを非表示にする。

## 関連Issue

- 関連Issue: #266

## 変更点

- 変更点1
通知リンク部分の<ResponsiveNavLink>を以下のコード部分でスタッフ（role=5）以上の権限でのみ表示されるよう修正。
```
v-if="page.props.auth.user_role <= 5"
```
- 変更点2
スマホ画面のログアウトのリンクが「Log Out」と英語だったので、日本語の「ログアウト」に修正。