### PR TITLE
fix:#297 該当箇所を「※毎朝6時更新」となっているのを「※平日0時更新」と修正

### DIFF
--- a/resources/js/Components/InspectionAndDisposalNotificationsTab.vue
+++ b/resources/js/Components/InspectionAndDisposalNotificationsTab.vue
@@ -44,7 +44,7 @@ const markAsRead = async (id: string): Promise<void> => {
 <template>
   <div>
     <div class="flex justify-around items-center">
-      <div class="my-4 px-4 font-medium text-xs md:text-base">※毎朝6時更新</div>
+      <div class="my-4 px-4 font-medium text-xs md:text-base">※平日0時更新</div>
       <Link :href="route('inspection_and_disposal_items')" class="px-4 text-blue-600 title-font font-medium text-xs md:text-base underline">
         点検と廃棄へ
       </Link>


### PR DESCRIPTION
## 目的

仕様の変更を反映していなかった文言の修正です。
平日の午前0時に点検・廃棄の予定があれば通知するように仕様を変更しましたが、表示されている文言に反映できていませんでした。

## 関連Issue

- 関連Issue: #297
スクリーンショットはこちらにあります。

## 変更点

- 変更点
通知画面の点検・廃棄予定タブで、「※毎朝6時更新」となっていたのを「※平日0時更新」と修正しました。