### PR TITLE
fix:#263 NotificationControllerのmarkAsReadメソッドを分離し、Apiフォルダ内にNotificationControllerを作成

### DIFF
--- a/app/Http/Controllers/Api/NotificationController.php
+++ b/app/Http/Controllers/Api/NotificationController.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Log;
+use App\Http\Controllers\Controller;
+
+class NotificationController extends Controller
+{
+    // 既読にするためのAPIエンドポイント
+    public function markAsRead($id)
+    {
+        Gate::authorize('staff-higher');
+
+        Log::info('NotificationController API markAsRead method called');
+
+        $notification = Auth::user()->notifications()->find($id);
+        if ($notification) {
+            $notification->markAsRead();
+            return response()->noContent(); // 204 レスポンスにコンテンツ含まれない
+        }
+
+        return response()->json(['status' => 'error'], 404);
+    }
+}

--- a/app/Http/Controllers/NotificationController.php
+++ b/app/Http/Controllers/NotificationController.php
@@ -2,15 +2,12 @@
 
 namespace App\Http\Controllers;
 
-use App\Http\Controllers\Controller;
-use Illuminate\Http\Request;
-use Illuminate\Notifications\Notification;
-use Inertia\Inertia;
-use App\Models\SystemNotification;
-use Illuminate\Support\Facades\Auth;
 use Carbon\Carbon;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Log;
+use Inertia\Inertia;
+use App\Http\Controllers\Controller;
 
 class NotificationController extends Controller
 {
@@ -19,12 +16,12 @@ class NotificationController extends Controller
         Gate::authorize('staff-higher');
 
         Log::info('NotificationController index method called');
-
-        // ログイン中のユーザーに向けた通知を取得
-        // $notifications = Auth::user()->notifications; ログイン中の通知
-        // $notifications = SystemNotification::all(); 全ての通知
+        
+        // Auth::user()->notifications; ログイン中ユーザーへの通知
+        // SystemNotification::all(); 全ての通知
         // ※情報がない場合、nullではなく空のコレクションとして扱われる
 
+        // ログイン中のユーザーに向けた通知を取得
         $notifications = Auth::user()->notifications->map(function ($notification) {
             $notification->id = (string) $notification->id; // UUIDを文字列として扱う、明示的に文字列としないと挙動がおかしくなる
             $notification->relative_time = Carbon::parse($notification->created_at)->diffForHumans(); // 相対的な時間を追加
@@ -74,21 +71,5 @@ class NotificationController extends Controller
             'unreadInspectionAndDisposalNotifications' => $unreadInspectionAndDisposalNotifications,
             'unreadRequestedItemNotifications' => $unreadRequestedItemNotifications,
         ]);
-    }
-
-    // 既読にするためのAPIエンドポイント
-    public function markAsRead($id)
-    {
-        Gate::authorize('staff-higher');
-
-        Log::info('NotificationController API markAsRead method called');
-
-        $notification = Auth::user()->notifications()->find($id);
-        if ($notification) {
-            $notification->markAsRead();
-            return response()->noContent(); // 204 レスポンスにコンテンツ含まれないｓ
-        }
-
-        return response()->json(['status' => 'error'], 404);
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -7,7 +7,7 @@ use App\Http\Controllers\Api\EdithistoryController;
 use App\Http\Controllers\ItemController;
 use App\Http\Controllers\ItemRequestController;
 use App\Http\Controllers\Api\StockTransactionController;
-use App\Http\Controllers\NotificationController;
+use App\Http\Controllers\Api\NotificationController;
 use App\Http\Controllers\VueErrorController;
 
 /*


### PR DESCRIPTION
## 目的

NotificationControllerには同期的なメソッドのindexメソッドと、非同期のAPIで使用するmarkAsReadメソッドが混在していました。把握を容易にするため、markAsReadメソッドはAPI用のコントローラーに分離しました。

## 関連Issue

- 関連Issue: #263

## 変更点

このセクションでは、具体的な変更点や修正箇所を箇条書きでリストアップしてください。

- 変更点1
従来のNotificationControllerからmarkAsReadメソッドを削除
- 変更点2
app\Http\Controllers\Api\NotificationController.php
にAPI用のNotificationControllerを作成し、markAsReadメソッドを配置
- 変更点3
api.phpで読み込んでいたNotificationControllerのnamespaceを修正
変更前：
```use App\Http\Controllers\NotificationController;```
変更後：
```use App\Http\Controllers\Api\NotificationController;```

## テスト

テストコードでのテストが難しいので、手動でテストしました。
