### PR TITLE
fix:#263 ItemRequestControllerのupdateStatusメソッドのみを、Api/ItemRequestConrollerへ移動、api.phpのuse分を修正

### DIFF
--- a/app/Http/Controllers/Api/ItemRequestController.php
+++ b/app/Http/Controllers/Api/ItemRequestController.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Log;
+use App\Http\Controllers\Controller;
+use App\Models\ItemRequest;
+
+
+class ItemRequestController extends Controller
+{    
+    public function updateStatus(Request $request, $id)
+    {
+        Gate::authorize('staff-higher');
+
+        Log::info('ItemRequestController updateStatus api method called');
+
+        // $idはURLパラメータから取得される
+        $itemRequest = ItemRequest::findOrFail($id);
+        $itemRequest->request_status_id = $request->requestStatusId;
+        $itemRequest->save();
+
+        Log::info('ItemRequestController updateStatus api method succeeded');
+
+        return response()->json(['message' => 'Status updated successfully'], 200);
+    }
+}

--- a/app/Http/Controllers/ItemRequestController.php
+++ b/app/Http/Controllers/ItemRequestController.php
@@ -2,18 +2,19 @@
 
 namespace App\Http\Controllers;
 
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Log;
+use Inertia\Inertia;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\StoreItemRequestRequest;
-use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Gate;
 use App\Models\ItemRequest;
 use App\Models\Category;
 use App\Models\Location;
 use App\Models\RequestStatus;
-use Illuminate\Support\Facades\Log;
-use Inertia\Inertia;
 use App\Events\RequestedItemDetectEvent;
-use Illuminate\Support\Facades\DB;
+
 
 class ItemRequestController extends Controller
 {
@@ -68,23 +69,6 @@ class ItemRequestController extends Controller
         ]); 
     }
     
-    // API通信用
-    public function updateStatus(Request $request, $id)
-    {
-        Gate::authorize('staff-higher');
-
-        Log::info('ItemRequestController updateStatus api method called');
-
-        // $idはURLパラメータから取得される
-        $itemRequest = ItemRequest::findOrFail($id);
-        $itemRequest->request_status_id = $request->requestStatusId;
-        $itemRequest->save();
-
-        Log::info('ItemRequestController updateStatus api method succeeded');
-
-        return response()->json(['message' => 'Status updated successfully'], 200);
-    }
-
     public function create()
     {
         Gate::authorize('user-higher');

--- a/routes/api.php
+++ b/routes/api.php
@@ -5,7 +5,7 @@ use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\ConsumableItemController;
 use App\Http\Controllers\Api\EdithistoryController;
 use App\Http\Controllers\ItemController;
-use App\Http\Controllers\ItemRequestController;
+use App\Http\Controllers\Api\ItemRequestController;
 use App\Http\Controllers\Api\StockTransactionController;
 use App\Http\Controllers\Api\NotificationController;
 use App\Http\Controllers\VueErrorController;


### PR DESCRIPTION
## 目的

ItemRequestControllerの同期的なメソッドと非同期的なメソッドが混在していました。
見る側が理解するのに労力を必要とするので、それを解消するために行いました。

## 関連Issue

- 関連Issue: #263

## 変更点

- 変更点1
ItemRequestControllerのupdateStatusメソッドを削除。
- 変更点2
Api/ItemRequestControllerを作成し、updateStatusメソッドを配置。
- 変更点3
api.phpのItemRequestControllerを読み込むuse文を修正。

## テスト

テストコードでのテストが難しいかったので、手動でテストしました。
正常に動作しました。