### PR TITLE
fix:#263 VueErrorControllerをapp/Http/Controllers/Apiフォルダに移動、namespaceを修正

### DIFF
--- a/app/Http/Controllers/Api/VueErrorController.php
+++ b/app/Http/Controllers/Api/VueErrorController.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Http\Controllers;
+namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;

--- a/routes/api.php
+++ b/routes/api.php
@@ -8,7 +8,7 @@ use App\Http\Controllers\ItemController;
 use App\Http\Controllers\Api\ItemRequestController;
 use App\Http\Controllers\Api\StockTransactionController;
 use App\Http\Controllers\Api\NotificationController;
-use App\Http\Controllers\VueErrorController;
+use App\Http\Controllers\Api\VueErrorController;
 
 /*
 |--------------------------------------------------------------------------


### PR DESCRIPTION
## 目的

VueErrorControllerはAPI通信用のコントローラーなので、見た人が理解しやすいようにapp/Http/Conrtorllers/ApiのAPI用のフォルダに移動する。

## 関連Issue

- 関連Issue: #263

## 変更点

- 変更点
VueErrorController.phpを移動
移動前
`app\Http\Controllers\VueErrorController.php`
移動後
`app\Http\Controllers\Api\VueErrorController.php`

## テスト

- テストケース
テストコードでのテストが難しいので、以下のようにItems/Index.vueにて強制的にエラーをスローするようにして、VueErrorControllerが正常に動作するか確かめました。
![image](https://github.com/user-attachments/assets/442f6cff-fee0-4aca-8d3f-6d7c13eee14f)

結果、以下のようにlaravel.logに該当のエラーが記録され、正常に動作していることが確認出来ました。
`[2024-12-11T18:28:16.489151+09:00] local.ERROR: Vue Error: {"user_id":2,"session_id":"$2y$10$ktyGKXyvsiobpiuVmyWxxe/VcHj76jysD.5pYwvJk4a5l.aOwo63C","url":"http://localhost:8000/api/log-error","error":"Error: Intentional Error","component":"Items/Index.vue toggleItems method"} {"file":"C:\\xampp\\htdocs\\laravel\\EMS\\app\\Http\\Controllers\\Api\\VueErrorController.php","line":14,"class":"App\\Http\\Controllers\\Api\\VueErrorController","callType":"->","function":"logError"}`