### PR TITLE
fix:#336 StockTransactionModalを閉じるイベント名を修正

### DIFF
--- a/resources/js/Components/StockTransactionModal.vue
+++ b/resources/js/Components/StockTransactionModal.vue
@@ -43,9 +43,9 @@ watch(() => props.item, (newItem: ItemType) => {
   }
 }, { immediate: true });
 
-const emit = defineEmits<{(e: 'close') : void}>();
+const emit = defineEmits<{(e: 'stockTransactionModalClosed') : void}>();
 const closeModal = (): void => {
-  emit('close') // StockTransactionModalを閉じるイベント打ち上げ
+  emit('stockTransactionModalClosed') // StockTransactionModalを閉じるイベント打ち上げ
 };
 </script>
 

--- a/resources/js/Pages/ConsumableItems/Index.vue
+++ b/resources/js/Pages/ConsumableItems/Index.vue
@@ -312,7 +312,7 @@ const fetchStock = async (itemId: number): Promise<void> => {
                                   </div>
                                 </div>
                               </template>
-                              <StockTransactionModal v-if="selectedStockTransactionItem && isStockTransactionModalOpen" :item="selectedStockTransactionItem" @close="closeStockTransactionModal" />
+                              <StockTransactionModal v-if="selectedStockTransactionItem && isStockTransactionModalOpen" :item="selectedStockTransactionItem" @stockTransactionModalClosed="closeStockTransactionModal" />
                               <UpdateStockModal v-if="selectedUpdateStockItem && isUpdateStockModalOpen" :item="selectedUpdateStockItem" :userName="userName" :errors="errors" @updateStockModalClosed="closeUpdateStockModal" />
                             </div>
                             <div v-else>


### PR DESCRIPTION
## 目的

消耗品管理画面(ConsumableItems/Index.vue)で開ける入出庫モーダル(StockTransactionModal.vue)を閉じる際に打ち上げるイベント名が分かりづらいものになっていたため修正すること。

## 関連Issue

- 関連Issue: #336

## 変更点

- 変更点1
StockTransactionModal.vueで打ち上げるイベント名を修正。
変更前：close
変更後：stockTransactionModalClosed

- 変更点2
それに合わせてイベントをキャッチするConsumableItems/Index.vue側も修正。

## テスト

フロント側のテストは書けていないので、自分で操作して確認しました。