### PR TITLE
CICD:#223 .gitignoreファイルの更新でECRへのイメージPUSHを確認

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ yarn-error.log
 /.vscode
 resources/fonts/
 coverage/
+aws/
+sessionmanager-bundle/


### PR DESCRIPTION
## 目的

pushしていなかった.gitignoreァイルの更新により、GitHub ActionsでECRへのイメージがpushされるか確認する

## 関連Issue

- 関連Issue: #223

## 変更点

- 変更点1
リポジトリのSettings -> Actions -> Generalで、Workflow permissionsの設定を以下のように変更
「Read and write permissions」->「Read repository contents and packages permissions」