### PR TITLE
CICD:#223 GitHub Actionsのデプロイ設定、タスク定義ファイルを作成

### DIFF
--- a/.aws/task-def-portfolio.json
+++ b/.aws/task-def-portfolio.json
@@ -1,0 +1,80 @@
+{
+    "containerDefinitions": [
+        {
+            "name": "portfolio-app-container",
+            "image": "<image uri>",
+            "cpu": 0,
+            "portMappings": [
+                {
+                    "name": "portfolio-80-tcp",
+                    "containerPort": 80,
+                    "hostPort": 80,
+                    "protocol": "tcp",
+                    "appProtocol": "http"
+                }
+            ],
+            "essential": true,
+            "environment": [
+                {
+                    "name": "DB_USERNAME",
+                    "value": "admin"
+                },
+                {
+                    "name": "DB_HOST",
+                    "value": "portfolio-rds.c9aewmioy4i5.ap-northeast-1.rds.amazonaws.com"
+                },
+                {
+                    "name": "DB_DATABASE",
+                    "value": "ems"
+                },
+            ],
+            "secrets": [
+                {
+                    "name": "AWS_ACCESS_KEY_ID",
+                    "valueFrom": "arn:aws:secretsmanager:ap-northeast-1:600627344486:secret:my-portfolio-task-definition-environment-variables-fiHdWF"
+                },
+                {
+                    "name": "AWS_SECRET_ACCESS_KEY",
+                    "valueFrom": "arn:aws:secretsmanager:ap-northeast-1:600627344486:secret:my-portfolio-task-definition-environment-variables-fiHdWF"
+                },
+                {
+                    "name": "DB_PASSWORD",
+                    "valueFrom": "arn:aws:secretsmanager:ap-northeast-1:600627344486:secret:my-portfolio-task-definition-environment-variables-fiHdWF"
+                }
+            ],
+            "environmentFiles": [],
+            "mountPoints": [],
+            "volumesFrom": [],
+            "ulimits": [],
+            "logConfiguration": {
+                "logDriver": "awslogs",
+                "options": {
+                    "awslogs-group": "/ecs/my-portfolio",
+                    "mode": "non-blocking",
+                    "awslogs-create-group": "true",
+                    "max-buffer-size": "25m",
+                    "awslogs-region": "ap-northeast-1",
+                    "awslogs-stream-prefix": "ecs"
+                },
+                "secretOptions": []
+            },
+            "systemControls": []
+        }
+    ],
+    "family": "my-portfolio",
+    "taskRoleArn": "ECSExecTaskRole",
+    "executionRoleArn": "ecsTaskExecutionRole",
+    "networkMode": "awsvpc",
+    "volumes": [],
+    "placementConstraints": [],
+    "requiresCompatibilities": [
+        "FARGATE"
+    ],
+    "cpu": "1024",
+    "memory": "2048",
+    "runtimePlatform": {
+        "cpuArchitecture": "X86_64",
+        "operatingSystemFamily": "LINUX"
+    },
+    "enableFaultInjection": false
+}

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -21,7 +21,7 @@ permissions:
 jobs:
 # Test
 # Build
-  Build:
+  build-and-push:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     defaults:
@@ -51,6 +51,52 @@ jobs:
         run: |
           docker image tag temp_portfolio_image:latest $ECR_REGISTRY/$ECS_REPOSITORY:${{ github.sha }}
           docker image push $ECR_REGISTRY/$ECS_REPOSITORY:${{ github.sha }}
+          echo $ECR_REGISTRY/$ECS_REPOSITORY:${{ github.sha }} > portfolio-image-uri.txt
 
+      - name: Upload the image uri file as an artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: portfolio-image-uri
+          path: portfolio-image-uri.txt
 
 # Deploy
+  deploy:
+    runs-on: ubuntu-latest
+    needs: [build-and-push]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Download the artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: portfolio-image-uri
+          path: artifacts
+
+      - name: Define the image URI
+        run: |
+          echo "API_IMAGE_URI=${cat artifacts/portfolio-image-uri.txt}" >> $GITHUB_ENV
+
+      - name: Fill in the new image URI in the amazon ECS task definition
+        id: render-task-def
+        uses: aws-actions/amazon-ecs-render-task-definition@v1
+        with:
+          task-definition: ${{ env.ECS_TASK_DEFINITION_API }}
+          container-name: portfolio-app-container
+          image: ${{ env.API_IMAGE_URI }}
+
+      - name: Deploy ECS task
+        uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+        with:
+          task-definition: ${{ steps.render-task-def.outputs.task-definition }}
+          service: ${{ env.ECS_SERVICE }}
+          cluster: ${{ env.ECS_CLUSTER }}
+          wait-for-service-stability: true


### PR DESCRIPTION
## 目的

GitHub ActionsでAWS ECSへのアプリのデプロイを行う。

## 関連Issue

- 関連Issue: #223

## 変更点

- 変更点1
cicd.ymlファイルを編集し、タスクデプロイのフローを作成
- 変更点2
.aws/task-def-portfolio.jsonでタスク定義を作成