### PR TITLE
CICD:#223 GitHub Actionsのデプロイ設定でartifactのactionをv4へ変更

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -54,7 +54,7 @@ jobs:
           echo $ECR_REGISTRY/$ECS_REPOSITORY:${{ github.sha }} > portfolio-image-uri.txt
 
       - name: Upload the image uri file as an artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: portfolio-image-uri
           path: portfolio-image-uri.txt
@@ -76,7 +76,7 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Download the artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: portfolio-image-uri
           path: artifacts
@@ -99,4 +99,4 @@ jobs:
           task-definition: ${{ steps.render-task-def.outputs.task-definition }}
           service: ${{ env.ECS_SERVICE }}
           cluster: ${{ env.ECS_CLUSTER }}
-          wait-for-service-stability: true
+          wait-for-service-stability:


### PR DESCRIPTION
## 目的

GitHub ActionsでAWS ECSへのアプリのデプロイを行う。

## 関連Issue

- 関連Issue: #223

## 変更点

- 変更点1
artifactのactionsのv2が既に廃止されていたので、推奨されているv4に変更しました。