### PR TITLE
CICD:#223 echoの書き方をzshからGitHubActionsのデフォルトシェルのbashに変更

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -83,7 +83,7 @@ jobs:
 
       - name: Define the image URI
         run: |
-          echo "API_IMAGE_URI=${cat artifacts/portfolio-image-uri.txt}" >> $GITHUB_ENV
+          echo "API_IMAGE_URI=$(cat artifacts/portfolio-image-uri.txt)" >> $GITHUB_ENV
 
       - name: Fill in the new image URI in the amazon ECS task definition
         id: render-task-def
@@ -99,4 +99,4 @@ jobs:
           task-definition: ${{ steps.render-task-def.outputs.task-definition }}
           service: ${{ env.ECS_SERVICE }}
           cluster: ${{ env.ECS_CLUSTER }}
-          wait-for-service-stability:
+          wait-for-service-stability: true


### PR DESCRIPTION
## 目的

GitHub ActionsでAWS ECSへのアプリのデプロイを行う。

## 関連Issue

- 関連Issue: #223

## 変更点

- 変更点1
echoの書き方でエラーが出たので修正しました。
GitHub Actionsのデフォルトシェルでは${ }ではなく $( )と入力する。