### PR TITLE
CICD:#223 タスク定義のJSONファイルの書き方が間違っていたので修正

### DIFF
--- a/.aws/task-def-portfolio.json
+++ b/.aws/task-def-portfolio.json
@@ -26,7 +26,7 @@
                 {
                     "name": "DB_DATABASE",
                     "value": "ems"
-                },
+                }
             ],
             "secrets": [
                 {


### PR DESCRIPTION
## 目的

GitHub ActionsでAWS ECSへのアプリのデプロイを行う。

## 関連Issue

このセクションでは、このPRが関連するIssueやタスクをリンクしてください。以下のように記述します。

- 関連Issue: #223

## 変更点

- 変更点1
タスク定義のJSONファイルに不要なコンマがあったので修正しました。