### PR TITLE
CICD:#223 タスク定義のエラーが出ていた部分を削除

### DIFF
--- a/.aws/task-def-portfolio.json
+++ b/.aws/task-def-portfolio.json
@@ -75,6 +75,5 @@
     "runtimePlatform": {
         "cpuArchitecture": "X86_64",
         "operatingSystemFamily": "LINUX"
-    },
-    "enableFaultInjection": false
+    }
 }


### PR DESCRIPTION
## 目的

GitHub ActionsでAWS ECSへのアプリのデプロイを行う。

## 関連Issue

- 関連Issue: #223

## 変更点

- 変更点1
タスク定義のエラーが出たオプションを削除しました。