### PR TITLE
CICD:#223 Dockerfileにphpコマンド追加、タスク定義にvolumeの定義を追加、cicd.ymlの不要なコードを削除

### DIFF
--- a/.aws/task-def-portfolio.json
+++ b/.aws/task-def-portfolio.json
@@ -23,9 +23,14 @@
                     "name": "AWS_SECRET_ACCESS_KEY",
                     "valueFrom": "arn:aws:secretsmanager:ap-northeast-1:600627344486:secret:my-portfolio-task-definition-environment-variables-fiHdWF"
                 }
-            ],
+            ],      
             "environmentFiles": [],
-            "mountPoints": [],
+            "mountPoints": [
+                {
+                "sourceVolume": "app-storage",
+                "containerPath": "/var/www/html/storage"
+                }
+            ],
             "volumesFrom": [],
             "ulimits": [],
             "logConfiguration": {
@@ -47,7 +52,14 @@
     "taskRoleArn": "ECSExecTaskRole",
     "executionRoleArn": "ecsTaskExecutionRole",
     "networkMode": "awsvpc",
-    "volumes": [],
+    "volumes": [
+        {
+            "name": "app-storage",
+            "host": {
+                "sourcePath": "/ecs/my-laravel-app-storage"
+            }
+        }
+    ],
     "placementConstraints": [],
     "requiresCompatibilities": [
         "FARGATE"

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -34,6 +34,7 @@ jobs:
       - name: Create .env file
         run: |
           cp .env.example .env
+          
           echo "APP_NAME=EMS" >> .env
           # APP_KEYは、イメージビルド時に「php artisan key:generate」を行う
           echo "APP_ENV=production" >> .env
@@ -41,11 +42,11 @@ jobs:
           echo "APP_URL=${{ secrets.PROD_APP_URL }}" >> .env
           echo "APP_PORT=80" >> .env
 
-          echo "SESSION_DOMAIN=${{ secrets.PROD_SESSION_DOMAIN }}" >> .env
           echo "DB_HOST=${{ secrets.PROD_DB_HOST }}" >> .env 
           echo "DB_DATABASE=${{ secrets.PROD_DB_DATABASE }}" >> .env
           echo "DB_USERNAME=${{ secrets.PROD_DB_USERNAME }}" >> .env
           echo "DB_PASSWORD=${{ secrets.PROD_DB_PASSWORD }}" >> .env
+
           echo "SESSION_DOMAIN=${{ secrets.PROD_SESSION_DOMAIN }}" >> .env
 
       - name: (Run Tests Feature Test ここは別jobに分離) Build Image

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,12 @@ RUN php artisan key:generate
 # アプリケーションのビルド
 RUN npm run build
 
+# シンボリックリンクの作成
+RUN php artisan storage:link
+
+# データベースのマイグレーションとシーディング
+RUN php artisan migrate:fresh --seed
+
 # ログディレクトリの所有者と権限を設定 
 RUN chown -R www-data:www-data /var/www/html/storage \
     && chmod -R 775 /var/www/html/storage


### PR DESCRIPTION
## 目的

GitHub ActionsでAWS ECSへのアプリのデプロイを行う。

## 関連Issue

- 関連Issue: #223

## 変更点

- 変更点1
デプロイ後手動でダミーデータを流すコマンドを打つ必要があったので、
Dockerfileに記載し自動で実行するように変更しました。
コマンド:
php artisan migrate:fresh --seed

- 変更点2
デプロイ後手動でシンボリックリンクの作成のコマンドを打つ必要があったので、
Dockerfileに記載し自動で実行するように変更しました。
コマンド:
php artisan storage:link

- 変更点3
デプロイ後、storage/app/public以下の画像が保存されていなかったので、
Volumesの設定が不足していたのが原因と仮定し、
storage以下がvolumesをマウントするようタスク定義にVolumeの設定を記載しました。

- 変更点4
cicd.ymlファイルで重複したコードがあったので削除しました。