### PR TITLE
CICD:#223 Dockerfileに追加したmigrateコマンド削除

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,9 +58,6 @@ RUN npm run build
 # シンボリックリンクの作成
 RUN php artisan storage:link
 
-# データベースのマイグレーションとシーディング
-RUN php artisan migrate:fresh --seed
-
 # ログディレクトリの所有者と権限を設定 
 RUN chown -R www-data:www-data /var/www/html/storage \
     && chmod -R 775 /var/www/html/storage


### PR DESCRIPTION
## 目的

GitHub ActionsでAWS ECSへのアプリのデプロイを行う。

## 関連Issue

- 関連Issue: #223

## 変更点

- 変更点1
Dockerfileの「php artisan migrate:fresh --seed」コマンドを削除しました。
イメージビルド時点では、まだAWS RDSに接続していないのでエラーが出たため。