### PR TITLE
CICD:#223 s3へ接続するために必要な.envの項目を追加

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -54,6 +54,10 @@ jobs:
 
           # ファイルシステムをs3に変更する設定
           echo "FILESYSTEM_DISK=s3" >> .env
+          echo "AWS_DEFAULT_REGION=${{ secrets.PROD_AWS_DEFAULT_REGION }}" >> .env
+          echo "AWS_BUCKET=${{ secrets.PROD_AWS_BUCKET }}" >> .env
+          echo "AWS_URL=${{ secrets.PROD_AWS_URL }}" >> .env
+          echo "AWS_ENDPOINT=${{ secrets.PROD_AWS_ENDPOINT }}" >> .env
 
       - name: (Run Tests Feature Test ここは別jobに分離) Build Image
         run: docker image build -t temp_portfolio_image:latest .


### PR DESCRIPTION
## 目的

GitHub ActionsでAWS ECSへのアプリのデプロイを行う。
その中でも、s3への接続設定にフォーカス。

## 関連Issue

- 関連Issue: #223

## 変更点

- 変更点1
s3への接続に必要な.envの項目を入力するようcicd.ymlファイルを編集しました。
理由：s3のbucketにstorage以下のファイルをアップロードしましたが、画像が表示されないため。