### PR TITLE
CICD:#223 s3との疎通確認のためのコンテナ内にAWS CLIをインストール、疎通確認用phpファイル作成

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,12 @@ RUN curl -sL https://deb.nodesource.com/setup_22.x | bash - \
 COPY package*.json ./
 RUN npm install
 
+# AWS CLIのインストール
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
+    && unzip awscliv2.zip \
+    && ./aws/install \
+    && rm -rf awscliv2.zip aws
+
 # Apacheのmod_rewriteを有効化
 RUN a2enmod rewrite
 

--- a/bucketList.php
+++ b/bucketList.php
@@ -1,0 +1,21 @@
+<?php
+require './vendor/autoload.php';
+
+use Aws\S3\S3Client;
+use Aws\S3\Exception\S3Exception;
+
+// S3インスタンス作成時の引数
+$s3 = new S3Client([
+    'region' => 'ap-northeast-1',
+    'version' => 'latest'
+]);
+
+# バケット一覧の表示
+try {
+    $result = $s3->listBuckets();
+    foreach ($result['Buckets'] as $bucket) {
+        echo $bucket['Name'] . "\n";
+    }
+} catch (\Throwable $e) {
+    echo $e->getMessage() . "\n";
+}


### PR DESCRIPTION
## 目的

GitHub ActionsでAWS ECSへのアプリのデプロイを行う。
その中でも、s3への接続設定にフォーカス。

## 関連Issue

- 関連Issue: #223

## 変更点

- 変更点1
DockerfileにAWS CLIをインストールするためのコマンドを追加しました。
理由：s3への接続確認のため。

- 変更点2
AWS SDKでの疎通確認ようのphpファイルを追加しました。
理由：s3への接続確認のため。