### PR TITLE
CICD:#223 AWS CLIをインストールするためにunzipコマンドが必要だったので追加

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get update && apt-get install -y \
     libmagickwand-dev \
     default-mysql-client \
     iputils-ping \
+    unzip \
     && docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp --with-xpm \
     && docker-php-ext-install -j$(nproc) gd \
     && docker-php-ext-install pdo pdo_mysql zip \


### PR DESCRIPTION
## 目的

GitHub ActionsでAWS ECSへのアプリのデプロイを行う。
その中でも、s3への接続設定にフォーカス。

## 関連Issue

- 関連Issue: #223

## 変更点

このセクションでは、具体的な変更点や修正箇所を箇条書きでリストアップしてください。

- 変更点1
unzipコマンドのインストールコマンドをDockerfileに追加しました。
理由：GitHub ActionsでのAWS CLIのインストールに必要なため。