### PR TITLE
CICD:#223 コンテナ内のAWS CLIの認証に干渉しているようなのでタスク定義の環境変数を削除

### DIFF
--- a/.aws/task-def-portfolio.json
+++ b/.aws/task-def-portfolio.json
@@ -13,17 +13,7 @@
                     "appProtocol": "http"
                 }
             ],
-            "essential": true,
-            "secrets": [
-                {
-                    "name": "AWS_ACCESS_KEY_ID",
-                    "valueFrom": "arn:aws:secretsmanager:ap-northeast-1:600627344486:secret:my-portfolio-task-definition-environment-variables-fiHdWF"
-                },
-                {
-                    "name": "AWS_SECRET_ACCESS_KEY",
-                    "valueFrom": "arn:aws:secretsmanager:ap-northeast-1:600627344486:secret:my-portfolio-task-definition-environment-variables-fiHdWF"
-                }
-            ],      
+            "essential": true,    
             "environmentFiles": [],
             "mountPoints": [],
             "volumesFrom": [],


### PR DESCRIPTION
## 目的

GitHub ActionsでAWS ECSへのアプリのデプロイを行う。
その中でも、s3への接続設定にフォーカス。

## 関連Issue

- 関連Issue: #223

## 変更点

- 変更点1
タスク定義の環境変数(AWS Secrets Managerを使用)を削除しました。
ECSコンテナ内でのAWS CLIの認証が、環境変数が干渉して失敗するため。