### PR TITLE
CICD:#223 s3を使用する時はシンボリックリンクの作成が不要なので、コマンドを削除

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,9 +62,6 @@ RUN php artisan key:generate
 # アプリケーションのビルド
 RUN npm run build
 
-# シンボリックリンクの作成
-RUN php artisan storage:link
-
 # ログディレクトリの所有者と権限を設定 
 RUN chown -R www-data:www-data /var/www/html/storage \
     && chmod -R 775 /var/www/html/storage


### PR DESCRIPTION
## 目的

開発環境およびAWSの本番環境で、画像が表示されない問題を解決すること。

## 関連Issue

- 関連Issue: #223

## 変更点

- 変更点1
Dockerfileの「php artisan storage:link」を削除しました。
理由：
本番環境でs3を使う場合は、シンボリックリンクの作成が不要なため。