### PR TITLE
CICD:#223 自動デプロイ時に自動でターゲットグループのターゲットが更新されるよう変更

### DIFF
--- a/.aws/task-def-portfolio.json
+++ b/.aws/task-def-portfolio.json
@@ -47,5 +47,12 @@
     "runtimePlatform": {
         "cpuArchitecture": "X86_64",
         "operatingSystemFamily": "LINUX"
-    }
+    },
+    "loadBalancers": [
+        {
+            "targetGroupArn": "arn:aws:elasticloadbalancing:ap-northeast-1:600627344486:targetgroup/my-portfolio-tg2/5b8786489a79571e",
+            "containerName": "portfolio-app-container",
+            "containerPort": 80
+        }
+    ]
 }


### PR DESCRIPTION
## 目的

AWS ECSに自動デプロイ時に、ターゲットグループのターゲットが新しいタスクに自動で変更されるようにすること。

## 関連Issue

- 関連Issue: #223

## 変更点

- 変更点1
タスク定義にロードバランサーのターゲットグループのARNを追加しました。
理由：
手動でターゲットグループのターゲットを切り替えるのが手間なため。