### PR TITLE
CICD:#223 タスク定義に書いたロードバランサーのターゲットグループの設定を削除

### DIFF
--- a/.aws/task-def-portfolio.json
+++ b/.aws/task-def-portfolio.json
@@ -47,12 +47,5 @@
     "runtimePlatform": {
         "cpuArchitecture": "X86_64",
         "operatingSystemFamily": "LINUX"
-    },
-    "loadBalancers": [
-        {
-            "targetGroupArn": "arn:aws:elasticloadbalancing:ap-northeast-1:600627344486:targetgroup/my-portfolio-tg2/5b8786489a79571e",
-            "containerName": "portfolio-app-container",
-            "containerPort": 80
-        }
-    ]
+    }
 }


### PR DESCRIPTION
## 目的

前回の以下の目的のために修正したタスク定義を元に戻すこと。
「AWS ECSに自動デプロイ時に、ターゲットグループのターゲットが新しいタスクに自動で変更されるようにすること。」

## 関連Issue

- 関連Issue: #223

## 変更点

- 変更点1
前回タスク定義に追加したロードバランサーのターゲットグループの部分を削除しました。
理由
タスク定義ではターゲットグループの設定は出来ないため。