### PR TITLE
CICD:#223 AuthenticatedLayout.vueのプロフィール画像のパスを修正

### DIFF
--- a/resources/js/Layouts/AuthenticatedLayout.vue
+++ b/resources/js/Layouts/AuthenticatedLayout.vue
@@ -27,8 +27,8 @@ const page: PageType = usePage();
 
 const profileImageUrl: ComputedRef<string> = computed(() =>{
     return page.props.auth.user.profile_image
-    ? `${import.meta.env.VITE_APP_URL}/storage/profile/${page.props.auth.user.profile_image}`
-    : `${import.meta.env.VITE_APP_URL}/storage/profile/profile_default_image.png`
+    ? `${import.meta.env.VITE_APP_URL}/profile/${page.props.auth.user.profile_image}`
+    : `${import.meta.env.VITE_APP_URL}/profile/profile_default_image.png`
 });
 </script>
 


### PR DESCRIPTION
## 目的

AuthenticatedLayout.vueのプロフィール画像がs3から取得できるよう修正。

## 関連Issue

- 関連Issue: #223

## 変更点

- 変更点1
AuthenticatedLayout.vueのプロフィール画像のパスを修正しました。