### PR TITLE
CICD:#223 s3のAWS_URLの値は不要なのでcicd.ymlからコマンドを削除

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -56,7 +56,6 @@ jobs:
           echo "FILESYSTEM_DISK=s3" >> .env
           echo "AWS_DEFAULT_REGION=${{ secrets.PROD_AWS_DEFAULT_REGION }}" >> .env
           echo "AWS_BUCKET=${{ secrets.PROD_AWS_BUCKET }}" >> .env
-          echo "AWS_URL=${{ secrets.PROD_AWS_URL }}" >> .env
           echo "AWS_ENDPOINT=${{ secrets.PROD_AWS_ENDPOINT }}" >> .env
 
           # ログの設定


### PR DESCRIPTION
## 目的

s3の画像を表示出来るようにすること。

## 関連Issue

- 関連Issue: #223

## 変更点

- 変更点1
s3を表示するのに.envのAWS_URLが不要なので、cicd.ymlの該当のコマンドを削除しました。