### PR TITLE
CICD:#223 s3のパススタイルエンドポイントを有効にしてみる

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -57,6 +57,7 @@ jobs:
           echo "AWS_DEFAULT_REGION=${{ secrets.PROD_AWS_DEFAULT_REGION }}" >> .env
           echo "AWS_BUCKET=${{ secrets.PROD_AWS_BUCKET }}" >> .env
           echo "AWS_ENDPOINT=${{ secrets.PROD_AWS_ENDPOINT }}" >> .env
+          echo "AWS_USE_PATH_STYLE_ENDPOINT=${{ secrets.PROD_AWS_USE_PATH_STYLE_ENDPOINT }}" >> .env
 
           # ログの設定
           echo "LOG_SLACK_WEBHOOK_URL=${{ secrets.PROD_LOG_SLACK_WEBHOOK_URL }}" >> .env


### PR DESCRIPTION
## 目的

s3の画像を表示出来るようにすること。

## 関連Issue

- 関連Issue: #223

## 変更点

- 変更点1
.envファイルに「AWS_USE_PATH_STYLE_ENDPOINT=true」を追加し、パススタイルエンドポイントを有効にする。
理由
パススタイルエンドポイントで問題が解決するか確認するため。