### PR TITLE
CICD:#223 開発環境のシンボリックリンクを本番環境では削除する

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,5 +66,8 @@ RUN npm run build
 RUN chown -R www-data:www-data /var/www/html/storage \
     && chmod -R 775 /var/www/html/storage
 
+# 本番環境でシンボリックリンクを削除
+RUN rm -f /var/www/html/public/storage
+
 # コンテナのポートを公開
 EXPOSE 80


### PR DESCRIPTION
## 目的

s3内の画像を表示できるようにすること。

## 関連Issue

- 関連Issue: #223

## 変更点

- 変更点1
Dockerfileにシンボリックリンクを削除するコマンドを追加。
理由
本番環境でs3を使用する場合、シンボリックリンクは必要ないため。
開発ツールのConsoleのエラーで、シンボリックリンクが原因で画像が表示されない可能性が示されたため。