### PR TITLE
CICD:#223 GitHub Actionsで.envに環境変数が追記されないので、もう一度やってみる

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -36,8 +36,8 @@ jobs:
           cp .env.example .env
           
           # APPの設定
-          echo "APP_NAME=EMS" >> .env
           # APP_KEYは、イメージビルド時に「php artisan key:generate」を行う
+          echo "APP_NAME=EMS" >> .env
           echo "APP_ENV=production" >> .env
           echo "APP_DEBUG=false" >> .env
           echo "APP_URL=${{ secrets.PROD_APP_URL }}" >> .env
@@ -69,7 +69,7 @@ jobs:
           # SANCTUMの設定
           echo "SANCTUM_STATEFUL_DOMAINS=${{ secrets.PROD_SANCTUM_STATEFUL_DOMAINS }}" >> .env
 
-      - name: (Run Tests Feature Test ここは別jobに分離) Build Image
+      - name: Build Image
         run: docker image build -t temp_portfolio_image:latest .
 
       - name: Configure AWS credentials


### PR DESCRIPTION
## 目的

GitHub Actionsで.envにymlファイルで指定した環境変数が追記されるか確認する。

## 関連Issue

- 関連Issue: #223

## 変更点

- 変更点1
cicd.ymlを少し整理しました。
理由
ECSコンテナ内の.envを見ると、GitHub Actionsで追記されるはずの環境変数がなかったので、
もう一度プルリクエストをマージして、GitHub Actionsを動かしてチェックするため。