### PR TITLE
CICD:#223 .envのAWS_USE_PATH_STYLE_ENDPOINTをfalseにする

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -57,7 +57,6 @@ jobs:
           echo "AWS_DEFAULT_REGION=${{ secrets.PROD_AWS_DEFAULT_REGION }}" >> .env
           echo "AWS_BUCKET=${{ secrets.PROD_AWS_BUCKET }}" >> .env
           echo "AWS_ENDPOINT=${{ secrets.PROD_AWS_ENDPOINT }}" >> .env
-          echo "AWS_USE_PATH_STYLE_ENDPOINT=${{ secrets.PROD_AWS_USE_PATH_STYLE_ENDPOINT }}" >> .env
 
           # ログの設定
           echo "LOG_SLACK_WEBHOOK_URL=${{ secrets.PROD_LOG_SLACK_WEBHOOK_URL }}" >> .env


### PR DESCRIPTION
## 目的

s3の画像を表示すること。

## 関連Issue

- 関連Issue: #223

## 変更点

- 変更点1
本番環境の.envがAWS_USE_PATH_STYLE_ENDPOINT=falseになるようcicd.ymlのコードを修正。
理由
本番環境のs3ではAWS_USE_PATH_STYLE_ENDPOINT=falseが必要なため。