### PR TITLE
CICD:#223 .envのAWS_ENDPOINTが不要なので、cicd.ymlからコマンドを削除

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -56,7 +56,6 @@ jobs:
           echo "FILESYSTEM_DISK=s3" >> .env
           echo "AWS_DEFAULT_REGION=${{ secrets.PROD_AWS_DEFAULT_REGION }}" >> .env
           echo "AWS_BUCKET=${{ secrets.PROD_AWS_BUCKET }}" >> .env
-          echo "AWS_ENDPOINT=${{ secrets.PROD_AWS_ENDPOINT }}" >> .env
 
           # ログの設定
           echo "LOG_SLACK_WEBHOOK_URL=${{ secrets.PROD_LOG_SLACK_WEBHOOK_URL }}" >> .env


### PR DESCRIPTION
## 目的

s3の画像を表示すること。

## 関連Issue

- 関連Issue: #223

## 変更点

- 変更点1
.envにAWS_ENDPOINTの設定を追加しないよう、cicd.ymlファイルを修正しました。
理由
s3用のVPCエンドポイントのタイプがGatewayの場合、DNS名は存在しません。
この場合、AWS_ENDPOINTは不要なようです。
（AWS_ENDPOINTには他のエンドポイントの値を参考に作成した値を入力していましたが、
本来は存在しませんでした。）