### PR TITLE
CICD:#223 Storage::diskの処理をs3に対応させる

### DIFF
--- a/app/Http/Controllers/ItemController.php
+++ b/app/Http/Controllers/ItemController.php
@@ -339,20 +339,20 @@ class ItemController extends Controller
 
             // アップロードした備品の画像の削除
             $imagePath = 'items/' . $fileNameToStore;
-            if (Storage::disk('public')->exists($imagePath)) {
-                Storage::disk('public')->delete($imagePath);
+            if (Storage::disk()->exists($imagePath)) {
+                Storage::disk()->delete($imagePath);
             }
 
             // qrCodeService内で保存したQRコードを削除
             $qrImagePath = 'qrcode/' . $qrCodeNameToStore;
-            if (Storage::disk('public')->exists($qrImagePath)) {
-                Storage::disk('public')->delete($qrImagePath);            
+            if (Storage::disk()->exists($qrImagePath)) {
+                Storage::disk()->delete($qrImagePath);            
             }
 
             // 保存したQRコードラベルを削除
             $labelImagePath = 'labels/' . $labelNameToStore;
-            if (Storage::disk('public')->exists($labelImagePath)) {
-                Storage::disk('public')->delete($labelImagePath);            
+            if (Storage::disk()->exists($labelImagePath)) {
+                Storage::disk()->delete($labelImagePath);            
             }
 
             return redirect()->back()
@@ -438,8 +438,8 @@ class ItemController extends Controller
         Log::info('ItemController update method called');
 
         // ロールバックした時の備品画像を元に戻す準備
-        if (!Storage::disk('public')->exists('temp')) {
-            Storage::disk('public')->makeDirectory('temp');
+        if (!Storage::disk()->exists('temp')) {
+            Storage::disk()->makeDirectory('temp');
         }
 
         // 編集理由はItemObserverのメソッド内でセッションから取得し、edithistoriesに保存
@@ -527,8 +527,8 @@ class ItemController extends Controller
                 if ($fileNameOfOldImage) {
                     $temporaryBackupPath = 'temp/'.$fileNameOfOldImage;
                     // 一時的な退避フォルダ(temp)に変更前の画像をコピーでバックアップ
-                    Storage::disk('public')->copy('items/'.$fileNameOfOldImage, $temporaryBackupPath);
-                    Storage::disk('public')->delete('items/'.$fileNameOfOldImage);
+                    Storage::disk()->copy('items/'.$fileNameOfOldImage, $temporaryBackupPath);
+                    Storage::disk()->delete('items/'.$fileNameOfOldImage);
                 }
 
                 // 画像ファイルのアップロードとDBのimage1のファイル名更新
@@ -573,25 +573,25 @@ class ItemController extends Controller
             ]);
 
             // アップロードしたプロフィール画像を削除
-            if (Storage::disk('public')->exists('items/' . $fileNameToStore)) {
-                Storage::disk('public')->delete('items/' . $fileNameToStore);
+            if (Storage::disk()->exists('items/' . $fileNameToStore)) {
+                Storage::disk()->delete('items/' . $fileNameToStore);
             }
 
             // バックアップした変更前の画像を元の場所に保存
             if ($temporaryBackupPath) {
-                Storage::disk('public')->move($temporaryBackupPath, 'items/'.$fileNameOfOldImage);
+                Storage::disk()->move($temporaryBackupPath, 'items/'.$fileNameOfOldImage);
             }
 
             // qrCodeService内で保存したQRコードを削除
             $qrImagePath = 'qrcode/' . $qrCodeNameToStore;
-            if (Storage::disk('public')->exists($qrImagePath)) {
-                Storage::disk('public')->delete($qrImagePath);            
+            if (Storage::disk()->exists($qrImagePath)) {
+                Storage::disk()->delete($qrImagePath);            
             }
 
             // 保存したQRコードラベルを削除
             $labelImagePath = 'labels/' . $labelNameToStore;
-            if (Storage::disk('public')->exists($labelImagePath)) {
-                Storage::disk('public')->delete($labelImagePath);            
+            if (Storage::disk()->exists($labelImagePath)) {
+                Storage::disk()->delete($labelImagePath);            
             }
 
             return redirect()->back()
@@ -603,7 +603,7 @@ class ItemController extends Controller
         } finally {
             // 成功しても失敗しても必ず行う処理
             if ($temporaryBackupPath) {
-                Storage::disk('public')->delete($temporaryBackupPath);
+                Storage::disk()->delete($temporaryBackupPath);
             }
         }
     }

--- a/app/Notifications/DisposalScheduleNotification.php
+++ b/app/Notifications/DisposalScheduleNotification.php
@@ -48,15 +48,17 @@ class DisposalScheduleNotification extends Notification
     public function toArray(object $notifiable): array
     {
         // 画像パスの設定
-        $imagePath = 'storage/items/' . $this->disposal->item->image1;
-        if (!$this->disposal->item->image1 || !Storage::disk('public')->exists('items/' . $this->disposal->item->image1)) {
-            $imagePath = 'storage/items/No_Image.jpg';
+        $defaultDisk = Storage::disk();
+        
+        $imagePath = $defaultDisk->url('items/' . $this->disposal->item->image1);
+        if (!$this->disposal->item->image1 || !$defaultDisk->exists('items/' . $this->disposal->item->image1)) {
+            $imagePath = $defaultDisk->url('items/No_Image.jpg');
         }
 
         return [
             'id' => $this->disposal->item->id,
             'management_id' => $this->disposal->item->management_id,
-            'image_path1' => asset($imagePath),
+            'image_path1' => $imagePath, //絶対URL
             'item_name' => $this->disposal->item->name,
             'scheduled_date' => $this->disposal ? $this->disposal->disposal_scheduled_date : null,
             'message' => '廃棄予定日が近づいています'

--- a/app/Notifications/InspectionScheduleNotification.php
+++ b/app/Notifications/InspectionScheduleNotification.php
@@ -48,16 +48,18 @@ class InspectionScheduleNotification extends Notification
     public function toArray(object $notifiable): array
     {
         // 画像パスの設定
-        $imagePath = 'storage/items/' . $this->inspection->item->image1;
-        if (!$this->inspection->item->image1 || !Storage::disk('public')->exists('items/' . $this->inspection->item->image1)) {
-            $imagePath = 'storage/items/No_Image.jpg';
+        $defaultDisk = Storage::disk();
+    
+        $imagePath = $defaultDisk->url('items/' . $this->inspection->item->image1);
+        if (!$this->inspection->item->image1 || !$defaultDisk->exists('items/' . $this->inspection->item->image1)) {
+            $imagePath = $defaultDisk->url('items/No_Image.jpg');
         }
 
         // ここで表示するのに必要な情報を詰め込む
         return [
             'id' => $this->inspection->item->id,
             'management_id' => $this->inspection->item->management_id,
-            'image_path1' => asset($imagePath),
+            'image_path1' => $imagePath, //絶対URL
             'item_name' => $this->inspection->item->name,
             'scheduled_date' => $this->inspection ? $this->inspection->inspection_scheduled_date : null,
             'message' => '点検予定日が近づいています'

--- a/app/Notifications/LowStockNotification.php
+++ b/app/Notifications/LowStockNotification.php
@@ -48,16 +48,18 @@ class LowStockNotification extends Notification
     public function toArray(object $notifiable): array
     {
         // 画像パスの設定
-        $imagePath = 'storage/items/' . $this->item->image1;
-        if (!$this->item->image1 || !Storage::disk('public')->exists('items/' . $this->item->image1)) {
-            $imagePath = 'storage/items/No_Image.jpg';
+        $defaultDisk = Storage::disk();
+
+        $imagePath = $defaultDisk->url('items/' . $this->item->image1);
+        if (!$this->item->image1 || !$defaultDisk->exists('items/' . $this->item->image1)) {
+            $imagePath = $defaultDisk->url('items/No_Image.jpg');
         }
 
         // ここで表示するのに必要な情報を詰め込む
         return [
             'id' => $this->item->id,
             'management_id' => $this->item->management_id,
-            'image_path1' => asset($imagePath),
+            'image_path1' => $imagePath,
             'item_name' => $this->item->name,
             'quantity' => $this->item->stock,
             'minimum_stock' => $this->item->minimum_stock,

--- a/app/Services/QrCodeService.php
+++ b/app/Services/QrCodeService.php
@@ -18,11 +18,11 @@ class QrCodeService
     Log::info('QrCodeService upload method called');
 
     try {
-      // $item->idを元にQRコードを生成する
-      $qrCode = QrCode::format('png')->size(300)->generate($item->id);
+      
+      $qrCode = QrCode::format('png')->size(300)->generate($item->id); // $item->idを元にQRコードを生成
       $qrCodeNameToStore = 'QR-' . uniqid(rand().'_') . '.png';
-      Storage::disk('public')->put('qrcode/'.$qrCodeNameToStore, $qrCode);
-      $qrCodefilePath = Storage::disk('public')->path('qrcode/'.$qrCodeNameToStore);
+      Storage::disk()->put('qrcode/'.$qrCodeNameToStore, $qrCode);
+      $qrCodefilePath = Storage::disk()->path('qrcode/'.$qrCodeNameToStore);
 
       $qrManager = new ImageManager(new Driver());
       $qrImage = $qrManager->read($qrCodefilePath);
@@ -47,7 +47,7 @@ class QrCodeService
       });
 
       $labelNameToStore = 'label-'.uniqid(rand().'_') .'.jpg';
-      Storage::disk('public')->put('labels/'.$labelNameToStore, $label->encode(new JpegEncoder()));
+      Storage::disk()->put('labels/'.$labelNameToStore, $label->encode(new JpegEncoder()));
 
       Log::info('QrCodeService upload method succeed');
 

--- a/tests/Feature/Http/Controllers/ItemController/Update/UpdateMethodTest.php
+++ b/tests/Feature/Http/Controllers/ItemController/Update/UpdateMethodTest.php
@@ -548,8 +548,8 @@ class UpdateMethodTest extends TestCase
         // $response->assertStatus(302);
 
         // 拡張子が.jpgで終わるファイルが存在するかを確認
-        // $files = Storage::disk('public')->assertExists('items/'.$fileNameToStore);
-        $files = Storage::disk('public')->files();
+        // $files = Storage::disk()->assertExists('items/'.$fileNameToStore);
+        $files = Storage::disk()->files();
         // dd($files);
         $jpgFilesExist = false;
         foreach ($files as $file) {

--- a/tests/Feature/Http/Controllers/ProfileController/UpdateMethodTest.php
+++ b/tests/Feature/Http/Controllers/ProfileController/UpdateMethodTest.php
@@ -134,7 +134,7 @@ class UpdateMethodTest extends TestCase
 
     //     Storage::fake('public');
     //     // 元々の画像ファイルをストレージに追加
-    //     Storage::disk('public')->put('profile/before_profile_image.jpg', 'dummy content');
+    //     Storage::disk()->put('profile/before_profile_image.jpg', 'dummy content');
 
     //     try {
     //         $response = $this->actingAs($user)
@@ -179,8 +179,8 @@ class UpdateMethodTest extends TestCase
     //     // $response->assertStatus(500);
 
     //     // プロフィール画像の削除が行われたかを確認
-    //     Storage::disk('public')->assertMissing('profile/mocked_profile_image.jpg');
-    //     Storage::disk('public')->assertExists('profile/before_profile_image.jpg');
+    //     Storage::disk()->assertMissing('profile/mocked_profile_image.jpg');
+    //     Storage::disk()->assertExists('profile/before_profile_image.jpg');
         
     //     $this->assertDatabaseHas('users', [
     //         'name' => 'BeforeTestUser',

--- a/tests/Feature/Services/ImageServiceTest.php
+++ b/tests/Feature/Services/ImageServiceTest.php
@@ -28,7 +28,7 @@ class ImageServiceTest extends TestCase
 
         dump($fileNameToStore);
 
-        Storage::disk('public')->assertExists('items/'.$fileNameToStore);
+        Storage::disk()->assertExists('items/'.$fileNameToStore);
     }
 
     /** @test */
@@ -42,7 +42,7 @@ class ImageServiceTest extends TestCase
 
         // dd($fileNameToStore);
 
-        Storage::disk('public')->assertExists('profile/'.$fileNameToStore);
+        Storage::disk()->assertExists('profile/'.$fileNameToStore);
     }
 
     /** @test */


### PR DESCRIPTION
## 目的

s3を使用するにあたりStorageファサードの処理をすべて修正する

## 関連Issue

- 関連Issue: #223

## 変更点

- 変更点1
コード内のStorage::disk('public')をすべてStorage::disk()に変更し、s3の環境でも動くように修正しました。