### PR TITLE
CICD:#223 Storage::diskでs3を使用してAuthenticatedLayout.vueのプロフィール画像を表示

### DIFF
--- a/app/Http/Controllers/Api/ProfileController.php
+++ b/app/Http/Controllers/Api/ProfileController.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Storage;
+
+class ProfileController extends Controller
+{
+    public function getProfileImage()
+    {
+        $user = Auth::user();
+        return response()->json([
+            'profile_image_url' => $user->profile_image
+                ? Storage::disk('s3')->url('profile/' . $user->profile_image)
+                : Storage::disk('s3')->url('profile/profile_default_image.png'),
+        ]);
+    }
+}

--- a/resources/js/Layouts/AuthenticatedLayout.vue
+++ b/resources/js/Layouts/AuthenticatedLayout.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed } from 'vue';
+import { ref, onMounted } from 'vue';
 import ApplicationLogo from '@/Components/ApplicationLogo.vue';
 import Dropdown from '@/Components/Dropdown.vue';
 import DropdownLink from '@/Components/DropdownLink.vue';
@@ -7,6 +7,7 @@ import NavLink from '@/Components/NavLink.vue';
 import ResponsiveNavLink from '@/Components/ResponsiveNavLink.vue';
 import { Link, usePage } from '@inertiajs/vue3';
 import BellNotification from '@/Components/BellNotification.vue';
+import axios from 'axios';
 import type { Ref, ComputedRef } from 'vue';
 import type { UserType } from '@/@types/model';
 
@@ -25,10 +26,19 @@ type PageType = {
 
 const page: PageType = usePage();
 
-const profileImageUrl: ComputedRef<string> = computed(() =>{
-    return page.props.auth.user.profile_image
-    ? `${import.meta.env.VITE_APP_URL}/profile/${page.props.auth.user.profile_image}`
-    : `${import.meta.env.VITE_APP_URL}/profile/profile_default_image.png`
+const profileImageUrl: Ref<string> = ref('');
+
+onMounted(() => {
+    axios.get('/api/profile-image')
+        .then(res => {
+            profileImageUrl.value = res.data.profile_image_url;
+        })
+        .catch(e => {
+            axios.post('/api/log-error', {
+                error: e.toString(),
+                component: 'AuthenticatedLayout.vue get profile_image_url',
+            });
+        });
 });
 </script>
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -66,6 +66,11 @@ Route::middleware(['auth:sanctum', 'verified', 'can:user-higher'])
 });
 
 
+// AuthenticatedLayout.vueのプロフィール画像URLを取得する
+Route::middleware(['auth:sanctum', 'verified', 'can:user-higher'])
+->get('/profile-image', [ProfileController::class, 'getProfileImage']);
+
+
 // Vue側のエラーをAPIでログに書き込む
 Route::middleware(['auth:sanctum', 'verified', 'can:user-higher'])
 ->post('/log-error', [VueErrorController::class, 'logError']);


### PR DESCRIPTION
## 目的

s3ディスクのStorage::diskで生成したプロフィール画像のURLを、AuthenticatedLayout.vue側でAPIを通じて取得すること。
## 関連Issue

- 関連Issue: #223

## 変更点

- 変更点1
AuthenticatedLayout.vueのフロント側でセッションから取得していたプロフィール画像のURLを、
Laravel側でプロフィール画像URLを取得する専用のAPIコントローラーを作成し、
AuthenticatedLayout.vueで非同期で取得できるようにしました。
理由
今までのフロント側のプロフィール画像のURL取得方法だと難易度が高いため。
また、画像URLの取得方法をバックエンドのLaravel側で取得するように統一するため。