### PR TITLE
CICD:#223 api.phpにApi\ProfileControllerのuse文を追加

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -9,6 +9,7 @@ use App\Http\Controllers\Api\StockTransactionController;
 use App\Http\Controllers\Api\NotificationController;
 use App\Http\Controllers\Api\UpdateStockController;
 use App\Http\Controllers\Api\VueErrorController;
+use App\Http\Controllers\Api\ProfileController;
 
 /*
 |--------------------------------------------------------------------------


### PR DESCRIPTION
## 目的

s3ディスクのStorage::diskで生成したプロフィール画像のURLを、AuthenticatedLayout.vue側でAPIを通じて取得すること。

## 関連Issue

- 関連Issue: #223

## 変更点

このセクションでは、具体的な変更点や修正箇所を箇条書きでリストアップしてください。

- 変更点1
api.phpにApi\ProfileControllerのuse文を追加しました。
理由
laravel.logを確認したところ、Api\ProfileControllerが見つからない旨のエラーがあったため。