### PR TITLE
#387: wkhtmltopdfのライブラリをインストールするため、Dockerfileのコマンドを修正

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,12 +22,22 @@ RUN apt-get update && apt-get install -y \
     libmagickwand-dev \
     default-mysql-client \
     iputils-ping \
-    unzip \
+    unzip
+
+# 別のRUNコマンドで追加の依存関係をインストール
+RUN apt-get update && apt-get install -y \  
     libssl1.1 \
     libxrender1 \
     libfontconfig1 \
-    wkhtmltopdf \
-    && docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp --with-xpm \
+    libxext6 \
+    libx11-6 \
+    libjpeg62-turbo-dev \
+    libpng-dev \
+    libfreetype6-dev \
+    wkhtmltopdf
+
+# GDライブラリの設定とインストール   
+RUN docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp --with-xpm \
     && docker-php-ext-install -j$(nproc) gd \
     && docker-php-ext-install pdo pdo_mysql zip \
     && pecl install imagick \


### PR DESCRIPTION
## 目的

PDFダウンロード機能を本番環境で実装する。

## 関連Issue

- 関連Issue: #387

## 変更点

- 変更点1
Dockerfileにwkhtmltopdfをインストールするために必要なライブラリを追加しました。
理由
GitHub Actionsのワークフローで、エラーとなったため。

- 変更点2
ワークフローのどの部分でエラーが起きたか分かりやすくするため、コマンドのグループを分けました。