### PR TITLE
#387: wkhtmltopdfのライブラリをインストールするため、Dockerfileのコマンドを修正

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,8 @@ RUN apt-get update && apt-get install -y \
     default-mysql-client \
     iputils-ping \
     unzip \
-    xfonts-75dpi
+    xfonts-75dpi \
+    xfonts-base
 
 # ライブラリファイルを取得
 RUN wget http://archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.0g-2ubuntu4_amd64.deb && \


### PR DESCRIPTION
## 目的

PDFダウンロード機能を本番環境で実装する。

## 関連Issue

- 関連Issue: #387

## 変更点

- 変更点1
Dockerfileにwkhtmltopdfに必要な xfonts-baseインストールコマンドを追加しました。