### PR TITLE
#387: composer.jsonのカンマ抜けを修正

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fc0ebe789d729b564b19e06d7f9ed11f"
+    "content-hash": "fc0ebe789d729b564b19e06d7f9ed11f",
     "packages": [
         {
             "name": "aws/aws-crt-php",


### PR DESCRIPTION
## 目的

PDFダウンロード機能を本番環境で実装する。

## 関連Issue

- 関連Issue: #387 

## 変更点

- 変更点1
composer.lockのカンマが抜けていたので修正しました。