### PR TITLE
#387: PDFControllerのStorageファサードのメソッドを修正

### DIFF
--- a/app/Http/Controllers/PDFController.php
+++ b/app/Http/Controllers/PDFController.php
@@ -28,7 +28,7 @@ class PDFController extends Controller
         // QRラベル画像のパスの配列を取得
         $qrCodes = [];
         foreach($consumableItems as $consumableItem) {
-            $qrCodes[] = Storage::path('labels/'.$consumableItem->qrcode);
+            $qrCodes[] = Storage::disk()->url('labels/'.$consumableItem->qrcode);
         }
 
         if (empty($qrCodes)) {


### PR DESCRIPTION
## 目的

PDFダウンロード機能を本番環境で実装する。

## 関連Issue

- 関連Issue: #387 

## 変更点

- 変更点1
PDFControllerのStorage::pathはs3ではサポートされていないので、
Storage::disk()->url()に修正しました。