### PR TITLE
fix:#315 LaravelのFeatureテストコードをフォーマット

### DIFF
--- a/tests/Feature/Api/Controllers/EdithistoryController/index/indexMethodTest.php
+++ b/tests/Feature/Api/Controllers/EdithistoryController/index/indexMethodTest.php
@@ -2,13 +2,13 @@
 
 namespace Tests\Feature\Api\Controllers\EdithistoryController\index;
 
+use App\Models\Edithistory;
+use App\Models\Item;
+use App\Models\User;
+use Faker\Factory as FakerFactory;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Testing\Fluent\AssertableJson;
-use Faker\Factory as FakerFactory;
 use Tests\TestCase;
-use App\Models\User;
-use App\Models\Item;
-use App\Models\Edithistory;
 
 class indexMethodTest extends TestCase
 {
@@ -23,17 +23,16 @@ class indexMethodTest extends TestCase
 
     protected function tearDown(): void
     {
-        // 子クラスでのクリーンアップ処理
         parent::tearDown();
     }
 
     // edithistoriesの編集履歴モーダル用のデータを取得できる
     /** @test */
-    function 編集履歴モーダル用のデータをAPIで取得できる()
+    public function 編集履歴モーダル用のデータをAPIで取得できる()
     {
-        // 世界の構築
+                                                    // 世界の構築
         $user = User::factory()->role(1)->create(); // adminユーザーを作成
-        $this->actingAs($user);   
+        $this->actingAs($user);
 
         $item = Item::factory()->create();
         // $item->idの編集履歴をDBに保存
@@ -46,30 +45,28 @@ class indexMethodTest extends TestCase
         // ])->get('/api/edithistory?item_id=' . $item->id);
 
         $response = $this->get('/api/edithistory?item_id=' . $item->id);
-        // $response = $this->get('/api/edithistory', ['item_id' => $item->id]);
+        // $response = $this->get('/api/edithistory', ['item_id' => $item->id]); //別な書き方
         $response->assertOk();
-        // dd($response->json());
-        
-        $response->assertJson(fn (AssertableJson $json) =>
-            $json->has('edithistories',10)
-                ->has('edithistories', fn ($json) =>
-                    $json->each(fn ($json) =>
+
+        $response->assertJson(fn(AssertableJson $json) =>
+            $json->has('edithistories', 10)
+                ->has('edithistories', fn($json) =>
+                    $json->each(fn($json) =>
                         $json->where('item_id', $item->id)
                             ->where('edit_mode', 'normal')
-                            ->where('operation_type', function($operation_type) {
+                            ->where('operation_type', function ($operation_type) {
                                 \Log::info('Operation Type: ' . $operation_type); // デバッグ出力
                                 return in_array($operation_type, ['store', 'update', 'soft_delete', 'restore']);
                             })
                             ->has('edited_field')
                             ->has('old_value')
                             ->has('new_value')
-                            ->where('edit_user', fn($edit_user) => !is_null($edit_user) && is_string($edit_user))
+                            ->where('edit_user', fn($edit_user) => ! is_null($edit_user) && is_string($edit_user))
                             ->has('edit_reason_id')
                             ->has('edit_reason_text')
                             ->etc()
+                    )
                 )
-            )
         );
     }
-
 }

--- a/tests/Feature/Api/Controllers/ItemController/Restore/RestoreMethodTest.php
+++ b/tests/Feature/Api/Controllers/ItemController/Restore/RestoreMethodTest.php
@@ -2,11 +2,11 @@
 
 namespace Tests\Feature\Api\Controllers\ItemController\Restore;
 
+use App\Models\Item;
+use App\Models\User;
+use Faker\Factory as FakerFactory;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
-use App\Models\User;
-use App\Models\Item;
-use Faker\Factory as FakerFactory;
 
 class RestoreMethodTest extends TestCase
 {
@@ -21,13 +21,11 @@ class RestoreMethodTest extends TestCase
 
     protected function tearDown(): void
     {
-        // 子クラスでのクリーンアップ処理
         parent::tearDown();
     }
 
-
     /** @test */
-    function 廃棄された備品を復元できる()
+    public function 廃棄された備品を復元できる()
     {
         // adminユーザーでログイン
         $user = User::factory()->role(1)->create();
@@ -40,25 +38,24 @@ class RestoreMethodTest extends TestCase
         // アイテムがソフトデリートされていることを確認
         $this->assertSoftDeleted('items', ['id' => $item->id]);
 
-
         // アイテムをAPI経由で復元
         $response = $this->json('POST', route('api.items.restore', ['id' => $item->id]));
 
         // レスポンスの確認
         $response->assertStatus(200)
-            ->assertJson([ 
-                'status' => 'success',
+            ->assertJson([
+                'status'  => 'success',
                 'message' => '備品を復元しました',
-                'item' => [ 
-                    'id' => $item->id,
+                'item'    => [
+                    'id'         => $item->id,
                     'deleted_at' => null,
-                ]
-         ]);
+                ],
+            ]);
 
         // アイテムが復元されたことを確認
         $this->assertDatabaseHas('items', [
-            'id' => $item->id,
-            'deleted_at' => null
+            'id'         => $item->id,
+            'deleted_at' => null,
         ]);
     }
 }

--- a/tests/Feature/Api/Controllers/StockTransactionController/index/indexMethodTest.php
+++ b/tests/Feature/Api/Controllers/StockTransactionController/index/indexMethodTest.php
@@ -1,15 +1,14 @@
 <?php
-
 namespace Tests\Feature\Api\Controllers\StockTransactionController\index;
 
+use App\Models\Item;
+use App\Models\StockTransaction;
+use App\Models\User;
+use Faker\Factory as FakerFactory;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Testing\Fluent\AssertableJson;
 use Inertia\Inertia;
-use Faker\Factory as FakerFactory;
 use Tests\TestCase;
-use App\Models\User;
-use App\Models\Item;
-use App\Models\StockTransaction;
 
 class indexMethodTest extends TestCase
 {
@@ -24,16 +23,15 @@ class indexMethodTest extends TestCase
 
     protected function tearDown(): void
     {
-        // 子クラスでのクリーンアップ処理
         parent::tearDown();
     }
 
     /** @test */
-    function 入出庫履歴モーダル用のデータをAPIで取得できる()
+    public function 入出庫履歴モーダル用のデータをAPIで取得できる()
     {
-        // 世界の構築
+                                                    // 世界の構築
         $user = User::factory()->role(1)->create(); // adminユーザーを作成
-        $this->actingAs($user);   
+        $this->actingAs($user);
 
         $item = Item::factory()->create();
         // $item->idの編集履歴をDBに保存
@@ -41,30 +39,29 @@ class indexMethodTest extends TestCase
 
         // Inertiaリクエストのシミュレーション、ヘッダーが追加される
         $response = $this->withHeaders([
-            'X-Inertia' => 'true',
+            'X-Inertia'         => 'true',
             'X-Inertia-Version' => Inertia::getVersion(),
         ])->get('/api/stock_transactions?item_id=' . $item->id);
-        
+
         $response->assertOk();
 
         // dd($response->json());
 
-        $response->assertJson(fn (AssertableJson $json) =>
+        $response->assertJson(fn(AssertableJson $json) =>
             $json->has('stockTransactions', 10)
-                ->has('stockTransactions', fn ($json) => 
-                    $json->each(fn ($json) => 
+                ->has('stockTransactions', fn($json) =>
+                    $json->each(fn($json) =>
                         $json->where('item_id', $item->id)
                             ->where('transaction_type', fn($type) => in_array($type, ['入庫', '出庫', '登録', '修正']))
                             ->where('quantity', fn($quantity) => is_int($quantity))
                             ->where('operator_name', fn($name) => is_string($name))
                             ->etc()
+                    )
                 )
-            )
-            ->has('labels', 10)
-            ->has('stocks', 10)
-            ->has('transaction_types', 10)
-            ->where('minimum_stock', fn($value) => is_int($value))
+                ->has('labels', 10)
+                ->has('stocks', 10)
+                ->has('transaction_types', 10)
+                ->where('minimum_stock', fn($value) => is_int($value))
         );
     }
-
 }

--- a/tests/Feature/Api/Controllers/UpdateStockController/getStock/getStockMethodTest.php
+++ b/tests/Feature/Api/Controllers/UpdateStockController/getStock/getStockMethodTest.php
@@ -2,11 +2,11 @@
 
 namespace Tests\Feature\Api\Controllers\UpdateStockController\getStock;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Faker\Factory as FakerFactory;
-use Tests\TestCase;
-use App\Models\User;
 use App\Models\Item;
+use App\Models\User;
+use Faker\Factory as FakerFactory;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
 
 class getStockMethodTest extends TestCase
 {
@@ -21,15 +21,13 @@ class getStockMethodTest extends TestCase
 
     protected function tearDown(): void
     {
-        // 子クラスでのクリーンアップ処理
         parent::tearDown();
     }
 
-
     /** @test */
-    function API通信で存在する備品の在庫数を取得できる()
+    public function API通信で存在する備品の在庫数を取得できる()
     {
-        // 世界の構築
+                                                    // 世界の構築
         $user = User::factory()->role(1)->create(); // adminユーザーを作成
         $this->actingAs($user);
 
@@ -44,16 +42,16 @@ class getStockMethodTest extends TestCase
     }
 
     /** @test */
-    function API通信で存在しないIDでは備品の在庫数を取得できない()
+    public function API通信で存在しないIDでは備品の在庫数を取得できない()
     {
-        // 世界の構築
+                                                    // 世界の構築
         $user = User::factory()->role(1)->create(); // adminユーザーを作成
         $this->actingAs($user);
 
         // 備品を作成
         $item = Item::factory()->create(['stock' => 10]);
 
-        $invalidItemId = $item->id + 1;        
+        $invalidItemId = $item->id + 1;
 
         // 存在しないIdでAPIにGETリクエストを送信
         $response = $this->getJson("/api/consumable_items/{$invalidItemId}/stock");

--- a/tests/Feature/Auth/AuthenticationTest.php
+++ b/tests/Feature/Auth/AuthenticationTest.php
@@ -23,7 +23,7 @@ class AuthenticationTest extends TestCase
         $user = User::factory()->create();
 
         $response = $this->post('/login', [
-            'email' => $user->email,
+            'email'    => $user->email,
             'password' => 'password',
         ]);
 
@@ -36,7 +36,7 @@ class AuthenticationTest extends TestCase
         $user = User::factory()->create();
 
         $this->post('/login', [
-            'email' => $user->email,
+            'email'    => $user->email,
             'password' => 'wrong-password',
         ]);
 

--- a/tests/Feature/Authorization/GuestAccessTest.php
+++ b/tests/Feature/Authorization/GuestAccessTest.php
@@ -2,38 +2,13 @@
 
 namespace Tests\Feature\Authorization;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
-use Tests\TestCase;
-use App\Models\User;
 use App\Models\Item;
-use App\Models\Unit;
-use App\Models\Category;
-use App\Models\Location;
-use App\Models\UsageStatus;
-use App\Models\AcquisitionMethod;
-use App\Models\Edithistory;
-use App\Models\Inspection;
-use App\Models\EditReason;
 use App\Models\ItemRequest;
-use App\Models\RequestStatus;
-use App\Models\StockTransaction;
-use App\Services\ImageService;
+use App\Models\User;
 use Faker\Factory as FakerFactory;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Inertia\Testing\AssertableInertia as Assert;
-use Mockery;
-use App\Services\ManagementIdService;
-use Illuminate\Support\Facades\Auth;
-use Carbon\Carbon;
-use Illuminate\Database\Console\DumpCommand;
-use Illuminate\Testing\Fluent\AssertableJson;
-use Inertia\Inertia;
-use Illuminate\Http\UploadedFile;
-use Illuminate\Support\Facades\Storage;
-use Intervention\Image\ImageManager;
-// use Intervention\Image\Drivers\Gd\Driver;
-use Intervention\Image\Drivers\Imagick\Driver;
-use Illuminate\Support\Facades\Session;
+use Tests\TestCase;
 
 class GuestAccessTest extends TestCase
 {
@@ -48,13 +23,12 @@ class GuestAccessTest extends TestCase
 
     protected function tearDown(): void
     {
-        // 子クラスでのクリーンアップ処理
         parent::tearDown();
     }
 
     /** @test */
-    function ゲストログインユーザーは画面にアクセスできる()
-    {   
+    public function ゲストログインユーザーは画面にアクセスできる()
+    {
         $loginUrl = 'login';
         // ゲストログインユーザー
         $user = User::factory()->role(0)->create();
@@ -67,7 +41,7 @@ class GuestAccessTest extends TestCase
 
         $this->get(route('items.index'))->assertOk();
         $this->get(route('items.create'))->assertOk();
-        $this->get(route('items.edit', ['item' => $item]))->assertOk();     
+        $this->get(route('items.edit', ['item' => $item]))->assertOk();
         $this->get(route('consumable_items'))->assertOk();
         $this->get(route('inspection_and_disposal_items'))->assertOk();
         $this->get(route('item_requests.index'))->assertOk();
@@ -77,8 +51,8 @@ class GuestAccessTest extends TestCase
     }
 
     /** @test */
-    function ゲストログインユーザーは備品の新規登録が許可されない()
-    {   
+    public function ゲストログインユーザーは備品の新規登録が許可されない()
+    {
         // ゲストログインユーザー
         $user = User::factory()->role(0)->create();
         $this->actingAs($user);
@@ -92,18 +66,18 @@ class GuestAccessTest extends TestCase
         $response = $this->followRedirects($response);
 
         // フラッシュメッセージの内容をアサート
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Create') // コンポーネント名を指定
-            ->has('flash.message')
-            ->where('flash.message', 'ゲストには許可されていない機能です、ログインして実行してください')
-            ->has('flash.status')
-            ->where('flash.status', 'danger')
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Create') // コンポーネント名を指定
+                ->has('flash.message')
+                ->where('flash.message', 'ゲストには許可されていない機能です、ログインして実行してください')
+                ->has('flash.status')
+                ->where('flash.status', 'danger')
         );
     }
 
     /** @test */
-    function ゲストログインユーザーは備品の編集更新が許可されない()
-    {   
+    public function ゲストログインユーザーは備品の編集更新が許可されない()
+    {
         // ゲストログインユーザー
         $user = User::factory()->role(0)->create();
         $this->actingAs($user);
@@ -117,8 +91,8 @@ class GuestAccessTest extends TestCase
         $response = $this->followRedirects($response);
 
         // フラッシュメッセージの内容をアサート
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Edit')
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Edit')
                 ->has('flash.message')
                 ->where('flash.message', 'ゲストには許可されていない機能です、ログインして実行してください')
                 ->has('flash.status')
@@ -127,8 +101,8 @@ class GuestAccessTest extends TestCase
     }
 
     /** @test */
-    function ゲストログインユーザーは備品の復元が許可されない()
-    {   
+    public function ゲストログインユーザーは備品の復元が許可されない()
+    {
         // ゲストログインユーザー
         $user = User::factory()->role(0)->create();
         $this->actingAs($user);
@@ -150,8 +124,8 @@ class GuestAccessTest extends TestCase
         $response = $this->followRedirects($response);
 
         // フラッシュメッセージの内容をアサート
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Index')
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Index')
                 ->has('flash.message')
                 ->where('flash.message', 'ゲストには許可されていない機能です、ログインして実行してください')
                 ->has('flash.status')
@@ -163,7 +137,7 @@ class GuestAccessTest extends TestCase
     }
 
     /** @test */
-    function 廃棄モーダルで廃棄の実施が許可されない()
+    public function 廃棄モーダルで廃棄の実施が許可されない()
     {
         // ゲストログインユーザー
         $user = User::factory()->role(0)->create();
@@ -178,8 +152,8 @@ class GuestAccessTest extends TestCase
         $response = $this->followRedirects($response);
 
         // フラッシュメッセージの内容をアサート
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Show')
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Show')
                 ->has('flash.message')
                 ->where('flash.message', 'ゲストには許可されていない機能です、ログインして実行してください')
                 ->has('flash.status')
@@ -188,7 +162,7 @@ class GuestAccessTest extends TestCase
     }
 
     /** @test */
-    function 点検モーダルで点検の実施が許可されない()
+    public function 点検モーダルで点検の実施が許可されない()
     {
         // ゲストログインユーザー
         $user = User::factory()->role(0)->create();
@@ -203,8 +177,8 @@ class GuestAccessTest extends TestCase
         $response = $this->followRedirects($response);
 
         // フラッシュメッセージの内容をアサート
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Show')
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Show')
                 ->has('flash.message')
                 ->where('flash.message', 'ゲストには許可されていない機能です、ログインして実行してください')
                 ->has('flash.status')
@@ -213,7 +187,7 @@ class GuestAccessTest extends TestCase
     }
 
     /** @test */
-    function 出庫モーダルで出庫の実施が許可されない()
+    public function 出庫モーダルで出庫の実施が許可されない()
     {
         // ゲストログインユーザー
         $user = User::factory()->role(0)->create();
@@ -228,8 +202,8 @@ class GuestAccessTest extends TestCase
         $response = $this->followRedirects($response);
 
         // フラッシュメッセージの内容をアサート
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('ConsumableItems/Index')
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('ConsumableItems/Index')
                 ->has('flash.message')
                 ->where('flash.message', 'ゲストには許可されていない機能です、ログインして実行してください')
                 ->has('flash.status')
@@ -238,7 +212,7 @@ class GuestAccessTest extends TestCase
     }
 
     /** @test */
-    function 入庫モーダルで入庫の実施が許可されない()
+    public function 入庫モーダルで入庫の実施が許可されない()
     {
         // ゲストログインユーザー
         $user = User::factory()->role(0)->create();
@@ -253,8 +227,8 @@ class GuestAccessTest extends TestCase
         $response = $this->followRedirects($response);
 
         // フラッシュメッセージの内容をアサート
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('ConsumableItems/Index')
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('ConsumableItems/Index')
                 ->has('flash.message')
                 ->where('flash.message', 'ゲストには許可されていない機能です、ログインして実行してください')
                 ->has('flash.status')
@@ -263,7 +237,7 @@ class GuestAccessTest extends TestCase
     }
 
     /** @test */
-    function リクエストの新規登録が許可されない()
+    public function リクエストの新規登録が許可されない()
     {
         // ゲストログインユーザー
         $user = User::factory()->role(0)->create();
@@ -276,8 +250,8 @@ class GuestAccessTest extends TestCase
         $response = $this->followRedirects($response);
 
         // フラッシュメッセージの内容をアサート
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('ItemRequests/Create')
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('ItemRequests/Create')
                 ->has('flash.message')
                 ->where('flash.message', 'ゲストには許可されていない機能です、ログインして実行してください')
                 ->has('flash.status')
@@ -286,7 +260,7 @@ class GuestAccessTest extends TestCase
     }
 
     /** @test */
-    function リクエストの削除が許可されない()
+    public function リクエストの削除が許可されない()
     {
         // ゲストログインユーザー
         $user = User::factory()->role(0)->create();
@@ -301,8 +275,8 @@ class GuestAccessTest extends TestCase
         $response = $this->followRedirects($response);
 
         // フラッシュメッセージの内容をアサート
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('ItemRequests/Index')
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('ItemRequests/Index')
                 ->has('flash.message')
                 ->where('flash.message', 'ゲストには許可されていない機能です、ログインして実行してください')
                 ->has('flash.status')
@@ -311,7 +285,7 @@ class GuestAccessTest extends TestCase
     }
 
     /** @test */
-    function APIによるリクエストのステータスの変更が許可されない()
+    public function APIによるリクエストのステータスの変更が許可されない()
     {
         $item_requests = ItemRequest::factory()->count(4)->create();
         // ゲストログインユーザー
@@ -329,12 +303,12 @@ class GuestAccessTest extends TestCase
         $response->assertStatus(403)
             ->assertJson([
                 'message' => 'ゲストには許可されていない機能です、ログインして実行してください',
-                'status' => 'danger'
+                'status'  => 'danger',
             ]);
     }
 
     /** @test */
-    function プロフィール情報の更新が許可されない()
+    public function プロフィール情報の更新が許可されない()
     {
         // ゲストログインユーザー
         $user = User::factory()->role(0)->create();
@@ -349,19 +323,12 @@ class GuestAccessTest extends TestCase
         $response = $this->followRedirects($response);
 
         // フラッシュメッセージの内容をアサート
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Profile/Edit')
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Profile/Edit')
                 ->has('flash.message')
                 ->where('flash.message', 'ゲストには許可されていない機能です、ログインして実行してください')
                 ->has('flash.status')
                 ->where('flash.status', 'danger')
         );
     }
-
-
-
-    
-
-    // プロフィール情報の更新
-
 }

--- a/tests/Feature/Authorization/UnauthenticatedUserTest.php
+++ b/tests/Feature/Authorization/UnauthenticatedUserTest.php
@@ -2,37 +2,10 @@
 
 namespace Tests\Feature\Authorization;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
-use Tests\TestCase;
-use App\Models\User;
 use App\Models\Item;
-use App\Models\Unit;
-use App\Models\Category;
-use App\Models\Location;
-use App\Models\UsageStatus;
-use App\Models\AcquisitionMethod;
-use App\Models\Edithistory;
-use App\Models\Inspection;
-use App\Models\EditReason;
-use App\Models\RequestStatus;
-use App\Models\StockTransaction;
-use App\Services\ImageService;
 use Faker\Factory as FakerFactory;
-use Inertia\Testing\AssertableInertia as Assert;
-use Mockery;
-use App\Services\ManagementIdService;
-use Illuminate\Support\Facades\Auth;
-use Carbon\Carbon;
-use Illuminate\Database\Console\DumpCommand;
-use Illuminate\Testing\Fluent\AssertableJson;
-use Inertia\Inertia;
-use Illuminate\Http\UploadedFile;
-use Illuminate\Support\Facades\Storage;
-use Intervention\Image\ImageManager;
-// use Intervention\Image\Drivers\Gd\Driver;
-use Intervention\Image\Drivers\Imagick\Driver;
-use Illuminate\Support\Facades\Session;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
 
 class UnauthenticatedUserTest extends TestCase
 {
@@ -47,15 +20,14 @@ class UnauthenticatedUserTest extends TestCase
 
     protected function tearDown(): void
     {
-        // 子クラスでのクリーンアップ処理
         parent::tearDown();
     }
 
     /** @test */
-    function ログインしていないユーザーはログイン後の画面にアクセスできない()
-    {   
+    public function ログインしていないユーザーはログイン後の画面にアクセスできない()
+    {
         $loginUrl = 'login';
-        // $user = User::factory()->role(1)->create();
+        // $user = User::factory()->role(1)->create(); // ログインはしない
         // $this->actingAs($user);
 
         $item = Item::factory()->create();
@@ -68,7 +40,7 @@ class UnauthenticatedUserTest extends TestCase
         $this->get(route('items.show', ['item' => $item]))->assertRedirect($loginUrl);
         $this->get(route('items.edit', ['item' => $item]))->assertRedirect($loginUrl);
         $this->from(route('items.edit', ['item' => $item]))->patch(route('items.update', $item->id), [])->assertRedirect($loginUrl);
-        
+
         // 詳細画面から廃棄できない
         $this->from(route('items.show', ['item' => $item]))
             ->put(route('dispose_item.disposeItem', ['item' => $item]), [])->assertRedirect($loginUrl);

--- a/tests/Feature/Http/Controllers/Auth/LoginTest.php
+++ b/tests/Feature/Http/Controllers/Auth/LoginTest.php
@@ -2,15 +2,11 @@
 
 namespace Tests\Feature\Http\Controllers\Auth;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
-use Tests\TestCase;
-use Faker\Factory as FakerFactory;
-use Inertia\Testing\AssertableInertia as Assert;
 use App\Models\User;
-
-use function Laravel\Prompts\error;
-use function Laravel\Prompts\password;
+use Faker\Factory as FakerFactory;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Inertia\Testing\AssertableInertia as Assert;
+use Tests\TestCase;
 
 class LoginTest extends TestCase
 {
@@ -20,12 +16,11 @@ class LoginTest extends TestCase
     {
         parent::setUp();
 
-        $this->faker = FakerFactory::create(); 
+        $this->faker = FakerFactory::create();
     }
 
     protected function tearDown(): void
     {
-        // 子クラスでのクリーンアップ処理
         parent::tearDown();
     }
 
@@ -41,7 +36,7 @@ class LoginTest extends TestCase
     {
         $response = $this->from('/login')
             ->post('/login', [
-                'email' => 'invalid@example.com',
+                'email'    => 'invalid@example.com',
                 'password' => 'invalidpassword',
             ]);
 
@@ -54,23 +49,23 @@ class LoginTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Auth/Login')
-            ->has('errors.email')
-            ->where('errors.email', 'ログイン情報が存在しません。')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Auth/Login')
+                ->has('errors.email')
+                ->where('errors.email', 'ログイン情報が存在しません。')
+                // ->dump()
         );
     }
 
-     /** @test */
-     public function Eメールとパスワードが空ではログインできない()
-     {
-         $response = $this->from('/login')
+    /** @test */
+    public function Eメールとパスワードが空ではログインできない()
+    {
+        $response = $this->from('/login')
             ->post('/login', [
-                'email' => '',
+                'email'    => '',
                 'password' => '',
             ]);
- 
+
         $response->assertSessionHasErrors(['email']);
         $response->assertStatus(302);
         $response->assertRedirect('/login');
@@ -79,13 +74,13 @@ class LoginTest extends TestCase
 
         // 実際はVue側でリアルタイムにバリデーションが行われるので
         // 開発ツールなどで入力しない限りは表示されない
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Auth/Login')
-            ->has('errors.email')
-            ->where('errors.email', 'メールアドレスは必ず指定してください。')
-            ->has('errors.password')
-            ->where('errors.password', 'パスワードは必ず指定してください。')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Auth/Login')
+                ->has('errors.email')
+                ->where('errors.email', 'メールアドレスは必ず指定してください。')
+                ->has('errors.password')
+                ->where('errors.password', 'パスワードは必ず指定してください。')
+                // ->dump()
         );
     }
 
@@ -98,7 +93,7 @@ class LoginTest extends TestCase
 
         $response = $this->from('/login')
             ->post('/login', [
-                'email' => $user->email,
+                'email'    => $user->email,
                 'password' => $password,
             ]);
 

--- a/tests/Feature/Http/Controllers/DashboardController/Index/IndexMethodTest.php
+++ b/tests/Feature/Http/Controllers/DashboardController/Index/IndexMethodTest.php
@@ -2,19 +2,16 @@
 
 namespace Tests\Feature\Http\Controllers\DashboardController\Index;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
-use Tests\TestCase;
-use Inertia\Testing\AssertableInertia as Assert;
-use Faker\Factory as FakerFactory;
-use App\Models\User;
-use App\Models\Item;
 use App\Models\Category;
-use App\Models\Location;
 use App\Models\Edithistory;
-use App\Models\EditReason;
+use App\Models\Item;
+use App\Models\Location;
+use App\Models\User;
 use Carbon\Carbon;
-use Illuminate\Support\Facades\Log;
+use Faker\Factory as FakerFactory;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Inertia\Testing\AssertableInertia as Assert;
+use Tests\TestCase;
 
 class IndexMethodTest extends TestCase
 {
@@ -29,17 +26,16 @@ class IndexMethodTest extends TestCase
 
     protected function tearDown(): void
     {
-        // 子クラスでのクリーンアップ処理
         parent::tearDown();
     }
 
     /** @test */
-    function DashboardControllerがすべての備品情報を渡せる_カテゴリでまとめた時()
+    public function DashboardControllerがすべての備品情報を渡せる_カテゴリでまとめた時()
     {
         Item::factory()->count(10)->create();
 
         $user = User::factory()->create([
-            'role' => 1
+            'role' => 1,
         ]);
         $this->actingAs($user);
 
@@ -48,19 +44,19 @@ class IndexMethodTest extends TestCase
 
         $this->assertCount(10, Item::all());
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Dashboard')
-            ->has('allItems', 10)
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Dashboard')
+                ->has('allItems', 10)
         );
     }
 
     /** @test */
-    function DashboardControllerがすべての備品情報を渡せる_利用場所でまとめた時()
+    public function DashboardControllerがすべての備品情報を渡せる_利用場所でまとめた時()
     {
         Item::factory()->count(10)->create();
 
         $user = User::factory()->create([
-            'role' => 1
+            'role' => 1,
         ]);
         $this->actingAs($user);
 
@@ -69,15 +65,14 @@ class IndexMethodTest extends TestCase
 
         $this->assertCount(10, Item::all());
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Dashboard')
-            ->has('allItems', 10)
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Dashboard')
+                ->has('allItems', 10)
         );
     }
 
-
     /** @test */
-    function DashboardControllerがカテゴリでまとめたデータを渡せる()
+    public function DashboardControllerがカテゴリでまとめたデータを渡せる()
     {
         // 世界を構築
         $categories = Category::factory()->count(11)->create();
@@ -87,35 +82,35 @@ class IndexMethodTest extends TestCase
         });
 
         $user = User::factory()->create([
-            'role' => 1
+            'role' => 1,
         ]);
         $this->actingAs($user);
 
         $response = $this->get('/dashboard?type=category')
             ->assertOk();
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Dashboard')
-            ->has('itemsByType', fn (Assert $data) =>
-                $categories->pluck('name')->each(fn ($name) =>
-                    $data->has($name)
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Dashboard')
+                ->has('itemsByType', fn(Assert $data) =>
+                    $categories->pluck('name')->each(fn($name) =>
+                        $data->has($name)
+                    )
                 )
-            )
         );
     }
 
     /** @test */
-    function DashboardControllerが利用場所でまとめたデータを渡せる()
+    public function DashboardControllerが利用場所でまとめたデータを渡せる()
     {
         // 世界を構築
-        $locations = Location::factory()->count(12)->create();        
+        $locations = Location::factory()->count(12)->create();
 
         $items = $locations->map(function ($location) {
             return Item::factory()->create(['location_of_use_id' => $location->id]);
         });
 
         $user = User::factory()->create([
-            'role' => 1
+            'role' => 1,
         ]);
         $this->actingAs($user);
 
@@ -124,21 +119,21 @@ class IndexMethodTest extends TestCase
         $response = $this->get('/dashboard?type=locationOfUse')
             ->assertOk();
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Dashboard')
-            ->has('itemsByType', fn (Assert $data) =>
-                $locations->pluck('name')->each(fn ($name) =>
-                    $data->has($name)
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Dashboard')
+                ->has('itemsByType', fn(Assert $data) =>
+                    $locations->pluck('name')->each(fn($name) =>
+                        $data->has($name)
+                    )
                 )
-            )
         );
     }
 
     /** @test */
-    function DashboardControllerが編集履歴のデータを渡せる()
+    public function DashboardControllerが編集履歴のデータを渡せる()
     {
         $user = User::factory()->create([
-            'role' => 1
+            'role' => 1,
         ]);
         $this->actingAs($user);
 
@@ -148,29 +143,29 @@ class IndexMethodTest extends TestCase
         // 4つの編集履歴を作成、当日にCarbon::now()を使うとおかしくなるので使用しない
         // $editHistory3,$editHistory4は同じ日付でまとめられているかテスト
         $editHistory1 = EditHistory::factory()->create([
-            'item_id' => $item->id,
+            'item_id'        => $item->id,
             'operation_type' => 'store',
-            'created_at' => Carbon::now()->subDays(1),
+            'created_at'     => Carbon::now()->subDays(1),
         ]);
         $editHistory2 = EditHistory::factory()->create([
-            'item_id' => $item->id,
+            'item_id'        => $item->id,
             'operation_type' => 'update',
-            'created_at' => Carbon::now()->subDays(2),
+            'created_at'     => Carbon::now()->subDays(2),
         ]);
         $editHistory3 = EditHistory::factory()->create([
-            'item_id' => $item->id,
+            'item_id'        => $item->id,
             'operation_type' => 'stock_in',
-            'created_at' => Carbon::now()->subDays(3),
+            'created_at'     => Carbon::now()->subDays(3),
         ]);
         $editHistory4 = EditHistory::factory()->create([
-            'item_id' => $item->id,
+            'item_id'        => $item->id,
             'operation_type' => 'stock_out',
-            'created_at' => Carbon::now()->subDays(3)->subHour(), //1時間前
+            'created_at'     => Carbon::now()->subDays(3)->subHour(), //1時間前
         ]);
 
         $response = $this->get('/dashboard')
             ->assertOk();
-        
+
         // slackにログ送信テスト用
         // Log::critical('editHistory1 created_at: ' . $editHistory1->created_at);
         // Log::critical('editHistory1 operation_type: ' . $editHistory1->operation_type);
@@ -179,22 +174,22 @@ class IndexMethodTest extends TestCase
         // Log::info('editHistory3 created_at: ' . $editHistory3->created_at);
         // Log::info('editHistory4 created_at: ' . $editHistory4->created_at);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Dashboard')
-            ->has('groupedEdithistories')     
-            ->has('groupedEdithistories.'.Carbon::now()->subDays(1)->format('Y-m-d')) //具体的な日付でグループ化されていることを確認する
-            ->where('groupedEdithistories.'.Carbon::now()->subDays(1)->format('Y-m-d').'.0.item_id', $editHistory1->item_id)
-            ->where('groupedEdithistories.'.Carbon::now()->subDays(1)->format('Y-m-d').'.0.operation_type', $editHistory1->operation_type)
-            ->has('groupedEdithistories.'.Carbon::now()->subDays(2)->format('Y-m-d')) 
-            ->where('groupedEdithistories.'.Carbon::now()->subDays(2)->format('Y-m-d').'.0.item_id', $editHistory2->item_id)
-            ->where('groupedEdithistories.'.Carbon::now()->subDays(2)->format('Y-m-d').'.0.operation_type', $editHistory2->operation_type)
-            ->has('groupedEdithistories.'.Carbon::now()->subDays(3)->format('Y-m-d')) 
-            ->where('groupedEdithistories.'.Carbon::now()->subDays(3)->format('Y-m-d').'.0.item_id', $editHistory3->item_id)
-            ->where('groupedEdithistories.'.Carbon::now()->subDays(3)->format('Y-m-d').'.0.operation_type', $editHistory3->operation_type)
-            ->has('groupedEdithistories.'.Carbon::now()->subDays(3)->format('Y-m-d')) 
-            ->where('groupedEdithistories.'.Carbon::now()->subDays(3)->format('Y-m-d').'.1.item_id', $editHistory4->item_id)
-            ->where('groupedEdithistories.'.Carbon::now()->subDays(3)->format('Y-m-d').'.1.operation_type', $editHistory4->operation_type)
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Dashboard')
+                ->has('groupedEdithistories')
+                ->has('groupedEdithistories.' . Carbon::now()->subDays(1)->format('Y-m-d')) //具体的な日付でグループ化されていることを確認する
+                ->where('groupedEdithistories.' . Carbon::now()->subDays(1)->format('Y-m-d') . '.0.item_id', $editHistory1->item_id)
+                ->where('groupedEdithistories.' . Carbon::now()->subDays(1)->format('Y-m-d') . '.0.operation_type', $editHistory1->operation_type)
+                ->has('groupedEdithistories.' . Carbon::now()->subDays(2)->format('Y-m-d'))
+                ->where('groupedEdithistories.' . Carbon::now()->subDays(2)->format('Y-m-d') . '.0.item_id', $editHistory2->item_id)
+                ->where('groupedEdithistories.' . Carbon::now()->subDays(2)->format('Y-m-d') . '.0.operation_type', $editHistory2->operation_type)
+                ->has('groupedEdithistories.' . Carbon::now()->subDays(3)->format('Y-m-d'))
+                ->where('groupedEdithistories.' . Carbon::now()->subDays(3)->format('Y-m-d') . '.0.item_id', $editHistory3->item_id)
+                ->where('groupedEdithistories.' . Carbon::now()->subDays(3)->format('Y-m-d') . '.0.operation_type', $editHistory3->operation_type)
+                ->has('groupedEdithistories.' . Carbon::now()->subDays(3)->format('Y-m-d'))
+                ->where('groupedEdithistories.' . Carbon::now()->subDays(3)->format('Y-m-d') . '.1.item_id', $editHistory4->item_id)
+                ->where('groupedEdithistories.' . Carbon::now()->subDays(3)->format('Y-m-d') . '.1.operation_type', $editHistory4->operation_type)
+                // ->dump()
         );
     }
 }

--- a/tests/Feature/Http/Controllers/DisposalController/disposeItem/diposeItemMethodTest.php
+++ b/tests/Feature/Http/Controllers/DisposalController/disposeItem/diposeItemMethodTest.php
@@ -2,37 +2,12 @@
 
 namespace Tests\Feature\Http\Controllers\DisposalController\disposeItem;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
-use Tests\TestCase;
-use App\Models\User;
 use App\Models\Item;
-use App\Models\Unit;
-use App\Models\Category;
-use App\Models\Location;
-use App\Models\UsageStatus;
-use App\Models\AcquisitionMethod;
-use App\Models\Edithistory;
-use App\Models\Inspection;
-use App\Models\EditReason;
-use App\Models\RequestStatus;
-use App\Models\StockTransaction;
-use App\Services\ImageService;
+use App\Models\User;
 use Faker\Factory as FakerFactory;
-use Inertia\Testing\AssertableInertia as Assert;
-use Mockery;
-use App\Services\ManagementIdService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Auth;
-use Carbon\Carbon;
-use Illuminate\Database\Console\DumpCommand;
-use Illuminate\Testing\Fluent\AssertableJson;
-use Inertia\Inertia;
-use Illuminate\Http\UploadedFile;
-use Illuminate\Support\Facades\Storage;
-use Intervention\Image\ImageManager;
-// use Intervention\Image\Drivers\Gd\Driver;
-use Intervention\Image\Drivers\Imagick\Driver;
-use Illuminate\Support\Facades\Session;
+use Tests\TestCase;
 
 class diposeItemMethodTest extends TestCase
 {
@@ -47,7 +22,6 @@ class diposeItemMethodTest extends TestCase
 
     protected function tearDown(): void
     {
-        // 子クラスでのクリーンアップ処理
         parent::tearDown();
     }
 
@@ -61,21 +35,21 @@ class diposeItemMethodTest extends TestCase
         $item = Item::factory()->create();
 
         $validData = [
-            'disposal_date' => '2024-09-03',
+            'disposal_date'   => '2024-09-03',
             'disposal_person' => $user->name,
-            'details' => 'あいうえお'
+            'details'         => 'あいうえお',
         ];
 
         // 備品を廃棄処理
-        $response = $this->from('items/'.$item->id)
+        $response = $this->from('items/' . $item->id)
             ->put(route('dispose_item.disposeItem', $item->id), $validData);
         $response->assertStatus(302); // リダイレクトを確認
         $response->assertRedirect('items');
 
         $this->assertDatabaseHas('disposals', [
-            'disposal_date' => '2024-09-03',
+            'disposal_date'   => '2024-09-03',
             'disposal_person' => $user->name,
-            'details' => 'あいうえお'
+            'details'         => 'あいうえお',
         ]);
 
         // ソフトデリートされたことを確認
@@ -87,16 +61,15 @@ class diposeItemMethodTest extends TestCase
         // ソフトデリートされた備品がwithTrashedで取得できることを確認
         $this->assertNotNull(Item::withTrashed()->find($item->id));
 
-
         // 廃棄した後ItemObserverによってeidithistorieテーブルに廃棄履歴が保存される
         $this->assertDatabaseHas('edithistories', [
-            'edit_mode' => 'normal',
+            'edit_mode'      => 'normal',
             'operation_type' => 'soft_delete',
-            'item_id' => $item->id,
-            'edited_field' => null,
-            'old_value' => null,
-            'new_value' => null,
-            'edit_user' => Auth::user()->name,
+            'item_id'        => $item->id,
+            'edited_field'   => null,
+            'old_value'      => null,
+            'new_value'      => null,
+            'edit_user'      => Auth::user()->name,
         ]);
     }
 }

--- a/tests/Feature/Http/Controllers/DisposalController/disposeItem/diposeItemValidationTest.php
+++ b/tests/Feature/Http/Controllers/DisposalController/disposeItem/diposeItemValidationTest.php
@@ -1,38 +1,12 @@
 <?php
-
 namespace Tests\Feature\Http\Controllers\DisposalController\disposeItem;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
-use Tests\TestCase;
-use App\Models\User;
 use App\Models\Item;
-use App\Models\Unit;
-use App\Models\Category;
-use App\Models\Location;
-use App\Models\UsageStatus;
-use App\Models\AcquisitionMethod;
-use App\Models\Edithistory;
-use App\Models\Inspection;
-use App\Models\EditReason;
-use App\Models\RequestStatus;
-use App\Models\StockTransaction;
-use App\Services\ImageService;
+use App\Models\User;
 use Faker\Factory as FakerFactory;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Inertia\Testing\AssertableInertia as Assert;
-use Mockery;
-use App\Services\ManagementIdService;
-use Illuminate\Support\Facades\Auth;
-use Carbon\Carbon;
-use Illuminate\Database\Console\DumpCommand;
-use Illuminate\Testing\Fluent\AssertableJson;
-use Inertia\Inertia;
-use Illuminate\Http\UploadedFile;
-use Illuminate\Support\Facades\Storage;
-use Intervention\Image\ImageManager;
-// use Intervention\Image\Drivers\Gd\Driver;
-use Intervention\Image\Drivers\Imagick\Driver;
-use Illuminate\Support\Facades\Session;
+use Tests\TestCase;
 
 class diposeItemValidationTest extends TestCase
 {
@@ -47,258 +21,257 @@ class diposeItemValidationTest extends TestCase
 
     protected function tearDown(): void
     {
-        // 子クラスでのクリーンアップ処理
         parent::tearDown();
     }
 
     // 備品廃棄モーダルでのバリデーションテスト
     /** @test */
-    function 廃棄モーダルバリデーションdisposal_dateがnullで無効値な場合()
+    public function 廃棄モーダルバリデーションdisposal_dateがnullで無効値な場合()
     {
         $user = User::factory()->role(1)->create();
         $this->actingAs($user);
 
         $item = Item::factory()->create();
 
-        $response = $this->from('items/'.$item->id)
+        $response = $this->from('items/' . $item->id)
             ->put(route('dispose_item.disposeItem', $item->id), ['disposal_date' => null]);
-        $response->assertRedirect('items/'.$item->id); //URLにリダイレクト
+        $response->assertRedirect('items/' . $item->id); //URLにリダイレクト
         $response->assertStatus(302);
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Show')
-            ->has('errors.disposal_date')
-            ->where('errors.disposal_date', '廃棄実施日は必ず指定してください。')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Show')
+                ->has('errors.disposal_date')
+                ->where('errors.disposal_date', '廃棄実施日は必ず指定してください。')
+                // ->dump()
         );
     }
 
     /** @test */
-    function 廃棄モーダルバリデーションdisposal_dateが文字列で無効値な場合()
+    public function 廃棄モーダルバリデーションdisposal_dateが文字列で無効値な場合()
     {
         $user = User::factory()->role(1)->create();
         $this->actingAs($user);
 
         $item = Item::factory()->create();
 
-        $response = $this->from('items/'.$item->id)
+        $response = $this->from('items/' . $item->id)
             ->put(route('dispose_item.disposeItem', $item->id), ['disposal_date' => 'あ']);
-        $response->assertRedirect('items/'.$item->id); //URLにリダイレクト
+        $response->assertRedirect('items/' . $item->id); //URLにリダイレクト
         $response->assertStatus(302);
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Show')
-            ->has('errors.disposal_date')
-            ->where('errors.disposal_date', '廃棄実施日には有効な日付を指定してください。')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Show')
+                ->has('errors.disposal_date')
+                ->where('errors.disposal_date', '廃棄実施日には有効な日付を指定してください。')
+                // ->dump()
         );
     }
 
     /** @test */
-    function 廃棄モーダルバリデーションdisposal_dateが数字で無効値な場合()
+    public function 廃棄モーダルバリデーションdisposal_dateが数字で無効値な場合()
     {
         $user = User::factory()->role(1)->create();
         $this->actingAs($user);
 
         $item = Item::factory()->create();
 
-        $response = $this->from('items/'.$item->id)
+        $response = $this->from('items/' . $item->id)
             ->put(route('dispose_item.disposeItem', $item->id), ['disposal_date' => 1]);
-        $response->assertRedirect('items/'.$item->id); //URLにリダイレクト
+        $response->assertRedirect('items/' . $item->id); //URLにリダイレクト
         $response->assertStatus(302);
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Show')
-            ->has('errors.disposal_date')
-            ->where('errors.disposal_date', '廃棄実施日には有効な日付を指定してください。')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Show')
+                ->has('errors.disposal_date')
+                ->where('errors.disposal_date', '廃棄実施日には有効な日付を指定してください。')
+                // ->dump()
         );
     }
-    
+
     /** @test */
-    function 廃棄モーダルバリデーションdisposal_personがnullで無効値な場合()
+    public function 廃棄モーダルバリデーションdisposal_personがnullで無効値な場合()
     {
         $user = User::factory()->role(1)->create();
         $this->actingAs($user);
 
         $item = Item::factory()->create();
 
-        $response = $this->from('items/'.$item->id)
+        $response = $this->from('items/' . $item->id)
             ->put(route('dispose_item.disposeItem', $item->id), ['disposal_person' => null]);
-        $response->assertRedirect('items/'.$item->id); //URLにリダイレクト
+        $response->assertRedirect('items/' . $item->id); //URLにリダイレクト
         $response->assertStatus(302);
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Show')
-            ->has('errors.disposal_person')
-            ->where('errors.disposal_person', '廃棄実施者は必ず指定してください。')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Show')
+                ->has('errors.disposal_person')
+                ->where('errors.disposal_person', '廃棄実施者は必ず指定してください。')
+                // ->dump()
         );
     }
-    
+
     /** @test */
-    function 廃棄モーダルバリデーションdisposal_personが1文字で有効値な場合()
+    public function 廃棄モーダルバリデーションdisposal_personが1文字で有効値な場合()
     {
         $user = User::factory()->role(1)->create();
         $this->actingAs($user);
 
         $item = Item::factory()->create();
 
-        $response = $this->from('items/'.$item->id)
+        $response = $this->from('items/' . $item->id)
             ->put(route('dispose_item.disposeItem', $item->id), ['disposal_person' => str_repeat('あ', 1)]);
-        $response->assertRedirect('items/'.$item->id); //URLにリダイレクト
+        $response->assertRedirect('items/' . $item->id); //URLにリダイレクト
         $response->assertStatus(302);
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Show')
-            ->missing('errors.disposal_person')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Show')
+                ->missing('errors.disposal_person')
+                // ->dump()
         );
     }
-    
+
     /** @test */
-    function 廃棄モーダルバリデーションdisposal_personが10文字で有効境界値の場合()
+    public function 廃棄モーダルバリデーションdisposal_personが10文字で有効境界値の場合()
     {
         $user = User::factory()->role(1)->create();
         $this->actingAs($user);
 
         $item = Item::factory()->create();
 
-        $response = $this->from('items/'.$item->id)
+        $response = $this->from('items/' . $item->id)
             ->put(route('dispose_item.disposeItem', $item->id), ['disposal_person' => str_repeat('あ', 10)]);
-        $response->assertRedirect('items/'.$item->id); //URLにリダイレクト
+        $response->assertRedirect('items/' . $item->id); //URLにリダイレクト
         $response->assertStatus(302);
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Show')
-            ->missing('errors.disposal_person')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Show')
+                ->missing('errors.disposal_person')
+                // ->dump()
         );
     }
-    
+
     /** @test */
-    function 廃棄モーダルバリデーションdisposal_personが11文字で無効境界値の場合()
+    public function 廃棄モーダルバリデーションdisposal_personが11文字で無効境界値の場合()
     {
         $user = User::factory()->role(1)->create();
         $this->actingAs($user);
 
         $item = Item::factory()->create();
 
-        $response = $this->from('items/'.$item->id)
+        $response = $this->from('items/' . $item->id)
             ->put(route('dispose_item.disposeItem', $item->id), ['disposal_person' => str_repeat('あ', 11)]);
-        $response->assertRedirect('items/'.$item->id); //URLにリダイレクト
+        $response->assertRedirect('items/' . $item->id); //URLにリダイレクト
         $response->assertStatus(302);
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Show')
-            ->has('errors.disposal_person')
-            ->where('errors.disposal_person', '廃棄実施者は、10文字以下で指定してください。')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Show')
+                ->has('errors.disposal_person')
+                ->where('errors.disposal_person', '廃棄実施者は、10文字以下で指定してください。')
+                // ->dump()
         );
     }
-    
+
     // 詳細情報のバリデーション
     /** @test */
-    function 廃棄モーダルバリデーションdetailsが空で無効値の場合()
+    public function 廃棄モーダルバリデーションdetailsが空で無効値の場合()
     {
         $user = User::factory()->role(1)->create();
         $this->actingAs($user);
 
         $item = Item::factory()->create();
 
-        $response = $this->from('items/'.$item->id)
+        $response = $this->from('items/' . $item->id)
             ->put(route('dispose_item.disposeItem', $item->id), ['details' => '']);
-        $response->assertRedirect('items/'.$item->id); //URLにリダイレクト
+        $response->assertRedirect('items/' . $item->id); //URLにリダイレクト
         $response->assertStatus(302);
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Show')
-            ->has('errors.details')
-            ->where('errors.details', '詳細情報は必ず指定してください。')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Show')
+                ->has('errors.details')
+                ->where('errors.details', '詳細情報は必ず指定してください。')
+                // ->dump()
         );
     }
 
     /** @test */
-    function 廃棄モーダルバリデーションdetailsが1文字で有効値の場合()
+    public function 廃棄モーダルバリデーションdetailsが1文字で有効値の場合()
     {
         $user = User::factory()->role(1)->create();
         $this->actingAs($user);
 
         $item = Item::factory()->create();
 
-        $response = $this->from('items/'.$item->id)
+        $response = $this->from('items/' . $item->id)
             ->put(route('dispose_item.disposeItem', $item->id), ['details' => str_repeat('あ', 1)]);
-        $response->assertRedirect('items/'.$item->id); //URLにリダイレクト
+        $response->assertRedirect('items/' . $item->id); //URLにリダイレクト
         $response->assertStatus(302);
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Show')
-            ->missing('errors.details')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Show')
+                ->missing('errors.details')
+                // ->dump()
         );
     }
 
     /** @test */
-    function 廃棄モーダルバリデーションdetailsが200文字で有効境界値の場合()
+    public function 廃棄モーダルバリデーションdetailsが200文字で有効境界値の場合()
     {
         $user = User::factory()->role(1)->create();
         $this->actingAs($user);
 
         $item = Item::factory()->create();
 
-        $response = $this->from('items/'.$item->id)
+        $response = $this->from('items/' . $item->id)
             ->put(route('dispose_item.disposeItem', $item->id), ['details' => str_repeat('あ', 200)]);
-        $response->assertRedirect('items/'.$item->id); //URLにリダイレクト
+        $response->assertRedirect('items/' . $item->id); //URLにリダイレクト
         $response->assertStatus(302);
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Show')
-            ->missing('errors.details')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Show')
+                ->missing('errors.details')
+                // ->dump()
         );
     }
 
     /** @test */
-    function 廃棄モーダルバリデーションdetailsが201文字で無効境界値の場合()
+    public function 廃棄モーダルバリデーションdetailsが201文字で無効境界値の場合()
     {
         $user = User::factory()->role(1)->create();
         $this->actingAs($user);
 
         $item = Item::factory()->create();
 
-        $response = $this->from('items/'.$item->id)
+        $response = $this->from('items/' . $item->id)
             ->put(route('dispose_item.disposeItem', $item->id), ['details' => str_repeat('あ', 201)]);
-        $response->assertRedirect('items/'.$item->id); //URLにリダイレクト
+        $response->assertRedirect('items/' . $item->id); //URLにリダイレクト
         $response->assertStatus(302);
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Show')
-            ->has('errors.details')
-            ->where('errors.details', '詳細情報は、200文字以下で指定してください。')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Show')
+                ->has('errors.details')
+                ->where('errors.details', '詳細情報は、200文字以下で指定してください。')
+                // ->dump()
         );
     }
 }

--- a/tests/Feature/Http/Controllers/InspectionAndDisposalItemController/index/indexMethodTest.php
+++ b/tests/Feature/Http/Controllers/InspectionAndDisposalItemController/index/indexMethodTest.php
@@ -2,16 +2,15 @@
 
 namespace Tests\Feature\Http\Controllers\InspectionAndDisposalItemController\index;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
-use Tests\TestCase;
-use Faker\Factory as FakerFactory;
-use App\Models\User;
-use App\Models\Item;
-use App\Models\Inspection;
 use App\Models\Disposal;
-use Inertia\Testing\AssertableInertia as Assert;
+use App\Models\Inspection;
+use App\Models\Item;
+use App\Models\User;
 use Carbon\Carbon;
+use Faker\Factory as FakerFactory;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Inertia\Testing\AssertableInertia as Assert;
+use Tests\TestCase;
 
 class IndexMethodTest extends TestCase
 {
@@ -26,12 +25,11 @@ class IndexMethodTest extends TestCase
 
     protected function tearDown(): void
     {
-        // 子クラスでのクリーンアップ処理
         parent::tearDown();
     }
 
     /** @test */
-    function 点検と廃棄画面の予定と履歴の情報をVue側に渡せる()
+    public function 点検と廃棄画面の予定と履歴の情報をVue側に渡せる()
     {
         // DBにデータを構築
         // Inspectionのデータ
@@ -49,7 +47,7 @@ class IndexMethodTest extends TestCase
         // 廃棄予定日
         $scheduledDisposals = Disposal::withoutEvents(function () {
             return Disposal::factory()->count(10)->create([
-                'item_id' => Item::factory()->create(['deleted_at' => null])->id, // 廃棄されていない
+                'item_id'                 => Item::factory()->create(['deleted_at' => null])->id, // 廃棄されていない
                 'disposal_scheduled_date' => Carbon::today()->addWeek(),
             ]);
         });
@@ -67,13 +65,13 @@ class IndexMethodTest extends TestCase
 
         $response = $this->get('/inspection-and-disposal-items')
             ->assertOk();
-        
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('InspectionAndDisposalItems/Index')
-            ->has('scheduledInspections.data', 10)
-            ->has('historyInspections.data', 10)
-            ->has('scheduledDisposals.data', 10)
-            ->has('historyDisposals.data', 10)
+
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('InspectionAndDisposalItems/Index')
+                ->has('scheduledInspections.data', 10)
+                ->has('historyInspections.data', 10)
+                ->has('scheduledDisposals.data', 10)
+                ->has('historyDisposals.data', 10)
         );
     }
 }

--- a/tests/Feature/Http/Controllers/InspectionController/inspectItem/inspectItemMethodTest.php
+++ b/tests/Feature/Http/Controllers/InspectionController/inspectItem/inspectItemMethodTest.php
@@ -2,37 +2,12 @@
 
 namespace Tests\Feature\Http\Controllers\InspectionController\inspectItem;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
-use Tests\TestCase;
-use App\Models\User;
-use App\Models\Item;
-use App\Models\Unit;
-use App\Models\Category;
-use App\Models\Location;
-use App\Models\UsageStatus;
-use App\Models\AcquisitionMethod;
-use App\Models\Edithistory;
 use App\Models\Inspection;
-use App\Models\EditReason;
-use App\Models\RequestStatus;
-use App\Models\StockTransaction;
-use App\Services\ImageService;
+use App\Models\Item;
+use App\Models\User;
 use Faker\Factory as FakerFactory;
-use Inertia\Testing\AssertableInertia as Assert;
-use Mockery;
-use App\Services\ManagementIdService;
-use Illuminate\Support\Facades\Auth;
-use Carbon\Carbon;
-use Illuminate\Database\Console\DumpCommand;
-use Illuminate\Testing\Fluent\AssertableJson;
-use Inertia\Inertia;
-use Illuminate\Http\UploadedFile;
-use Illuminate\Support\Facades\Storage;
-use Intervention\Image\ImageManager;
-// use Intervention\Image\Drivers\Gd\Driver;
-use Intervention\Image\Drivers\Imagick\Driver;
-use Illuminate\Support\Facades\Session;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
 
 class inspectItemMethodTest extends TestCase
 {
@@ -47,12 +22,11 @@ class inspectItemMethodTest extends TestCase
 
     protected function tearDown(): void
     {
-        // 子クラスでのクリーンアップ処理
         parent::tearDown();
     }
 
     /** @test */
-    function 備品詳細画面で点検モーダルで点検処理できる_点検予定日のレコードがない場合()
+    public function 備品詳細画面で点検モーダルで点検処理できる_点検予定日のレコードがない場合()
     {
         $user = User::factory()->role(1)->create();
         $this->actingAs($user);
@@ -61,25 +35,25 @@ class inspectItemMethodTest extends TestCase
         $item = Item::factory()->create();
 
         $validData = [
-            'inspection_date' => '2024-09-03',
+            'inspection_date'   => '2024-09-03',
             'inspection_person' => $user->name,
-            'details' => 'あいうえお'
+            'details'           => 'あいうえお',
         ];
 
         // 備品をソフトデリート
-        $response = $this->from('items/'.$item->id)
+        $response = $this->from('items/' . $item->id)
             ->put(route('inspect_item.inspectItem', $item->id), $validData);
         $response->assertStatus(302); // リダイレクトを確認
 
         $this->assertDatabaseHas('inspections', [
-            'inspection_date' => '2024-09-03',
+            'inspection_date'   => '2024-09-03',
             'inspection_person' => $user->name,
-            'details' => 'あいうえお'
+            'details'           => 'あいうえお',
         ]);
     }
 
     /** @test */
-    function 備品詳細画面で点検モーダルで点検処理できる_点検予定日のレコードがある場合()
+    public function 備品詳細画面で点検モーダルで点検処理できる_点検予定日のレコードがある場合()
     {
         $user = User::factory()->role(1)->create();
         $this->actingAs($user);
@@ -88,31 +62,31 @@ class inspectItemMethodTest extends TestCase
         $item = Item::factory()->create();
 
         $validData = [
-            'inspection_date' => '2024-09-03',
+            'inspection_date'   => '2024-09-03',
             'inspection_person' => $user->name,
-            'details' => 'あいうえお'
+            'details'           => 'あいうえお',
         ];
 
         // inspection_scheduled_dateが登録されていてstatusがfalseの場合、
         $inspection = Inspection::withoutEvents(function () use ($item) {
             return Inspection::factory()->create([
-                'item_id' => $item->id,
+                'item_id'                   => $item->id,
                 'inspection_scheduled_date' => '2024-09-01',
-                'inspection_date' => null,
-                'status' => false,
-                'inspection_person' => null,
-                'details' => null
+                'inspection_date'           => null,
+                'status'                    => false,
+                'inspection_person'         => null,
+                'details'                   => null,
             ]);
         });
         // 備品をソフトデリート
-        $response = $this->from('items/'.$item->id)
+        $response = $this->from('items/' . $item->id)
             ->put(route('inspect_item.inspectItem', $item->id), $validData);
         $response->assertStatus(302); // リダイレクトを確認
 
         $this->assertDatabaseHas('inspections', [
-            'inspection_date' => '2024-09-03',
+            'inspection_date'   => '2024-09-03',
             'inspection_person' => $user->name,
-            'details' => 'あいうえお'
+            'details'           => 'あいうえお',
         ]);
 
         // 先にinspectionが存在した場合更新されているかをアサ―ト

--- a/tests/Feature/Http/Controllers/InspectionController/inspectItem/inspectItemValidationTest.php
+++ b/tests/Feature/Http/Controllers/InspectionController/inspectItem/inspectItemValidationTest.php
@@ -2,37 +2,12 @@
 
 namespace Tests\Feature\Http\Controllers\InspectionController\inspectItem;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
-use Tests\TestCase;
-use App\Models\User;
 use App\Models\Item;
-use App\Models\Unit;
-use App\Models\Category;
-use App\Models\Location;
-use App\Models\UsageStatus;
-use App\Models\AcquisitionMethod;
-use App\Models\Edithistory;
-use App\Models\Inspection;
-use App\Models\EditReason;
-use App\Models\RequestStatus;
-use App\Models\StockTransaction;
-use App\Services\ImageService;
+use App\Models\User;
 use Faker\Factory as FakerFactory;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Inertia\Testing\AssertableInertia as Assert;
-use Mockery;
-use App\Services\ManagementIdService;
-use Illuminate\Support\Facades\Auth;
-use Carbon\Carbon;
-use Illuminate\Database\Console\DumpCommand;
-use Illuminate\Testing\Fluent\AssertableJson;
-use Inertia\Inertia;
-use Illuminate\Http\UploadedFile;
-use Illuminate\Support\Facades\Storage;
-use Intervention\Image\ImageManager;
-// use Intervention\Image\Drivers\Gd\Driver;
-use Intervention\Image\Drivers\Imagick\Driver;
-use Illuminate\Support\Facades\Session;
+use Tests\TestCase;
 
 class inspectItemValidationTest extends TestCase
 {
@@ -47,13 +22,12 @@ class inspectItemValidationTest extends TestCase
 
     protected function tearDown(): void
     {
-        // 子クラスでのクリーンアップ処理
         parent::tearDown();
     }
 
     // 点検予定日のレコードがない場合でテスト
     /** @test */
-    function 点検モーダルバリデーションinspection_dateがnullで無効値の場合()
+    public function 点検モーダルバリデーションinspection_dateがnullで無効値の場合()
     {
         $user = User::factory()->role(1)->create();
         $this->actingAs($user);
@@ -62,23 +36,23 @@ class inspectItemValidationTest extends TestCase
         $item = Item::factory()->create();
 
         // 備品をソフトデリート
-        $response = $this->from('items/'.$item->id)
+        $response = $this->from('items/' . $item->id)
             ->put(route('inspect_item.inspectItem', $item->id), ['inspection_date' => null]);
-        $response->assertRedirect('items/'.$item->id);
+        $response->assertRedirect('items/' . $item->id);
         $response->assertStatus(302);
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Show')
-            ->has('errors.inspection_date')
-            ->where('errors.inspection_date', '点検実施日は必ず指定してください。')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Show')
+                ->has('errors.inspection_date')
+                ->where('errors.inspection_date', '点検実施日は必ず指定してください。')
+                // ->dump()
         );
     }
 
     /** @test */
-    function 点検モーダルバリデーションinspection_dateが文字列で無効値の場合()
+    public function 点検モーダルバリデーションinspection_dateが文字列で無効値の場合()
     {
         $user = User::factory()->role(1)->create();
         $this->actingAs($user);
@@ -87,23 +61,23 @@ class inspectItemValidationTest extends TestCase
         $item = Item::factory()->create();
 
         // 備品をソフトデリート
-        $response = $this->from('items/'.$item->id)
+        $response = $this->from('items/' . $item->id)
             ->put(route('inspect_item.inspectItem', $item->id), ['inspection_date' => 'あ']);
-        $response->assertRedirect('items/'.$item->id);
+        $response->assertRedirect('items/' . $item->id);
         $response->assertStatus(302);
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Show')
-            ->has('errors.inspection_date')
-            ->where('errors.inspection_date', '点検実施日には有効な日付を指定してください。')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Show')
+                ->has('errors.inspection_date')
+                ->where('errors.inspection_date', '点検実施日には有効な日付を指定してください。')
+                // ->dump()
         );
     }
 
     /** @test */
-    function 点検モーダルバリデーションinspection_dateが数字で無効値の場合()
+    public function 点検モーダルバリデーションinspection_dateが数字で無効値の場合()
     {
         $user = User::factory()->role(1)->create();
         $this->actingAs($user);
@@ -112,198 +86,198 @@ class inspectItemValidationTest extends TestCase
         $item = Item::factory()->create();
 
         // 備品をソフトデリート
-        $response = $this->from('items/'.$item->id)
+        $response = $this->from('items/' . $item->id)
             ->put(route('inspect_item.inspectItem', $item->id), ['inspection_date' => 1]);
-        $response->assertRedirect('items/'.$item->id);
+        $response->assertRedirect('items/' . $item->id);
         $response->assertStatus(302);
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Show')
-            ->has('errors.inspection_date')
-            ->where('errors.inspection_date', '点検実施日には有効な日付を指定してください。')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Show')
+                ->has('errors.inspection_date')
+                ->where('errors.inspection_date', '点検実施日には有効な日付を指定してください。')
+                // ->dump()
         );
     }
 
     /** @test */
-    function 点検モーダルバリデーションinspection_personがnullの場合()
+    public function 点検モーダルバリデーションinspection_personがnullの場合()
     {
         $user = User::factory()->role(1)->create();
         $this->actingAs($user);
 
         $item = Item::factory()->create();
 
-        $response = $this->from('items/'.$item->id)
+        $response = $this->from('items/' . $item->id)
             ->put(route('inspect_item.inspectItem', $item->id), ['inspection_person' => null]);
-        $response->assertRedirect('items/'.$item->id);
+        $response->assertRedirect('items/' . $item->id);
         $response->assertStatus(302);
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Show')
-            ->has('errors.inspection_person')
-            ->where('errors.inspection_person', '点検実施者は必ず指定してください。')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Show')
+                ->has('errors.inspection_person')
+                ->where('errors.inspection_person', '点検実施者は必ず指定してください。')
+                // ->dump()
         );
     }
-    
+
     /** @test */
-    function 点検モーダルバリデーションinspection_personが1文字で有効値な場合()
+    public function 点検モーダルバリデーションinspection_personが1文字で有効値な場合()
     {
         $user = User::factory()->role(1)->create();
         $this->actingAs($user);
 
         $item = Item::factory()->create();
 
-        $response = $this->from('items/'.$item->id)
+        $response = $this->from('items/' . $item->id)
             ->put(route('inspect_item.inspectItem', $item->id), ['inspection_person' => str_repeat('あ', 1)]);
-        $response->assertRedirect('items/'.$item->id);
+        $response->assertRedirect('items/' . $item->id);
         $response->assertStatus(302);
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Show')
-            ->missing('errors.inspection_person')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Show')
+                ->missing('errors.inspection_person')
+                // ->dump()
         );
     }
-    
+
     /** @test */
-    function 点検モーダルバリデーションinspection_personが10文字で有効境界値の場合()
+    public function 点検モーダルバリデーションinspection_personが10文字で有効境界値の場合()
     {
         $user = User::factory()->role(1)->create();
         $this->actingAs($user);
 
         $item = Item::factory()->create();
 
-        $response = $this->from('items/'.$item->id)
+        $response = $this->from('items/' . $item->id)
             ->put(route('inspect_item.inspectItem', $item->id), ['inspection_person' => str_repeat('あ', 10)]);
-        $response->assertRedirect('items/'.$item->id);
+        $response->assertRedirect('items/' . $item->id);
         $response->assertStatus(302);
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Show')
-            ->missing('errors.inspection_person')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Show')
+                ->missing('errors.inspection_person')
+                // ->dump()
         );
     }
-    
+
     /** @test */
-    function 点検モーダルバリデーションinspection_personが11文字で無効境界値の場合()
+    public function 点検モーダルバリデーションinspection_personが11文字で無効境界値の場合()
     {
         $user = User::factory()->role(1)->create();
         $this->actingAs($user);
 
         $item = Item::factory()->create();
 
-        $response = $this->from('items/'.$item->id)
+        $response = $this->from('items/' . $item->id)
             ->put(route('inspect_item.inspectItem', $item->id), ['inspection_person' => str_repeat('あ', 11)]);
-        $response->assertRedirect('items/'.$item->id);
+        $response->assertRedirect('items/' . $item->id);
         $response->assertStatus(302);
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Show')
-            ->has('errors.inspection_person')
-            ->where('errors.inspection_person', '点検実施者は、10文字以下で指定してください。')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Show')
+                ->has('errors.inspection_person')
+                ->where('errors.inspection_person', '点検実施者は、10文字以下で指定してください。')
+                // ->dump()
         );
     }
-    
+
     /** @test */
-    function 点検モーダルバリデーションdetailsがnullで無効の場合()
+    public function 点検モーダルバリデーションdetailsがnullで無効の場合()
     {
         $user = User::factory()->role(1)->create();
         $this->actingAs($user);
 
         $item = Item::factory()->create();
 
-        $response = $this->from('items/'.$item->id)
+        $response = $this->from('items/' . $item->id)
             ->put(route('inspect_item.inspectItem', $item->id), ['details' => null]);
-        $response->assertRedirect('items/'.$item->id);
+        $response->assertRedirect('items/' . $item->id);
         $response->assertStatus(302);
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Show')
-            ->has('errors.details')
-            ->where('errors.details', '詳細情報は必ず指定してください。')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Show')
+                ->has('errors.details')
+                ->where('errors.details', '詳細情報は必ず指定してください。')
+                // ->dump()
         );
     }
-    
+
     /** @test */
-    function 点検モーダルバリデーションdetailsが1文字で有効な場合()
+    public function 点検モーダルバリデーションdetailsが1文字で有効な場合()
     {
         $user = User::factory()->role(1)->create();
         $this->actingAs($user);
 
         $item = Item::factory()->create();
 
-        $response = $this->from('items/'.$item->id)
+        $response = $this->from('items/' . $item->id)
             ->put(route('inspect_item.inspectItem', $item->id), ['details' => str_repeat('あ', 1)]);
-        $response->assertRedirect('items/'.$item->id);
+        $response->assertRedirect('items/' . $item->id);
         $response->assertStatus(302);
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Show')
-            ->missing('errors.details')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Show')
+                ->missing('errors.details')
+                // ->dump()
         );
     }
-    
+
     /** @test */
-    function 点検モーダルバリデーションdetailsが200文字で有効境界値な場合()
+    public function 点検モーダルバリデーションdetailsが200文字で有効境界値な場合()
     {
         $user = User::factory()->role(1)->create();
         $this->actingAs($user);
 
         $item = Item::factory()->create();
 
-        $response = $this->from('items/'.$item->id)
+        $response = $this->from('items/' . $item->id)
             ->put(route('inspect_item.inspectItem', $item->id), ['details' => str_repeat('あ', 200)]);
-        $response->assertRedirect('items/'.$item->id);
+        $response->assertRedirect('items/' . $item->id);
         $response->assertStatus(302);
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Show')
-            ->missing('errors.details')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Show')
+                ->missing('errors.details')
+                // ->dump()
         );
     }
-    
+
     /** @test */
-    function 点検モーダルバリデーションdetailsが201文字で無効境界値な場合()
+    public function 点検モーダルバリデーションdetailsが201文字で無効境界値な場合()
     {
         $user = User::factory()->role(1)->create();
         $this->actingAs($user);
 
         $item = Item::factory()->create();
 
-        $response = $this->from('items/'.$item->id)
+        $response = $this->from('items/' . $item->id)
             ->put(route('inspect_item.inspectItem', $item->id), ['details' => str_repeat('あ', 201)]);
-        $response->assertRedirect('items/'.$item->id);
+        $response->assertRedirect('items/' . $item->id);
         $response->assertStatus(302);
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Show')
-            ->has('errors.details')
-            ->where('errors.details', '詳細情報は、200文字以下で指定してください。')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Show')
+                ->has('errors.details')
+                ->where('errors.details', '詳細情報は、200文字以下で指定してください。')
+                // ->dump()
         );
     }
 }

--- a/tests/Feature/Http/Controllers/ItemController/Create/CreateMethodTest.php
+++ b/tests/Feature/Http/Controllers/ItemController/Create/CreateMethodTest.php
@@ -2,37 +2,10 @@
 
 namespace Tests\Feature\Http\Controllers\ItemController\Create;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
-use Tests\TestCase;
 use App\Models\User;
-use App\Models\Item;
-use App\Models\Unit;
-use App\Models\Category;
-use App\Models\Location;
-use App\Models\UsageStatus;
-use App\Models\AcquisitionMethod;
-use App\Models\Edithistory;
-use App\Models\Inspection;
-use App\Models\EditReason;
-use App\Models\RequestStatus;
-use App\Models\StockTransaction;
-use App\Services\ImageService;
 use Faker\Factory as FakerFactory;
-use Inertia\Testing\AssertableInertia as Assert;
-use Mockery;
-use App\Services\ManagementIdService;
-use Illuminate\Support\Facades\Auth;
-use Carbon\Carbon;
-use Illuminate\Database\Console\DumpCommand;
-use Illuminate\Testing\Fluent\AssertableJson;
-use Inertia\Inertia;
-use Illuminate\Http\UploadedFile;
-use Illuminate\Support\Facades\Storage;
-use Intervention\Image\ImageManager;
-// use Intervention\Image\Drivers\Gd\Driver;
-use Intervention\Image\Drivers\Imagick\Driver;
-use Illuminate\Support\Facades\Session;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
 
 class CreateMethodTest extends TestCase
 {
@@ -47,18 +20,17 @@ class CreateMethodTest extends TestCase
 
     protected function tearDown(): void
     {
-        // 子クラスでのクリーンアップ処理
         parent::tearDown();
     }
 
     /** @test */
-    function 備品新規登録画面を開く()
+    public function 備品新規登録画面を開く()
     {
         // 全ての権限で画面を開く
         $roles = [
             'admin' => 1,
             'staff' => 5,
-            'user' => 9,
+            'user'  => 9,
         ];
 
         foreach ($roles as $roleName => $role) {

--- a/tests/Feature/Http/Controllers/ItemController/Edit/EditMethodTest.php
+++ b/tests/Feature/Http/Controllers/ItemController/Edit/EditMethodTest.php
@@ -2,37 +2,11 @@
 
 namespace Tests\Feature\Http\Controllers\ItemController\Edit;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
-use Tests\TestCase;
-use App\Models\User;
 use App\Models\Item;
-use App\Models\Unit;
-use App\Models\Category;
-use App\Models\Location;
-use App\Models\UsageStatus;
-use App\Models\AcquisitionMethod;
-use App\Models\Edithistory;
-use App\Models\Inspection;
-use App\Models\EditReason;
-use App\Models\RequestStatus;
-use App\Models\StockTransaction;
-use App\Services\ImageService;
+use App\Models\User;
 use Faker\Factory as FakerFactory;
-use Inertia\Testing\AssertableInertia as Assert;
-use Mockery;
-use App\Services\ManagementIdService;
-use Illuminate\Support\Facades\Auth;
-use Carbon\Carbon;
-use Illuminate\Database\Console\DumpCommand;
-use Illuminate\Testing\Fluent\AssertableJson;
-use Inertia\Inertia;
-use Illuminate\Http\UploadedFile;
-use Illuminate\Support\Facades\Storage;
-use Intervention\Image\ImageManager;
-// use Intervention\Image\Drivers\Gd\Driver;
-use Intervention\Image\Drivers\Imagick\Driver;
-use Illuminate\Support\Facades\Session;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
 
 class EditMethodTest extends TestCase
 {
@@ -47,18 +21,17 @@ class EditMethodTest extends TestCase
 
     protected function tearDown(): void
     {
-        // 子クラスでのクリーンアップ処理
         parent::tearDown();
     }
 
     /** @test */
-    function 備品編集画面を開く()
+    public function 備品編集画面を開く()
     {
         // 全ての権限で画面を開く
         $roles = [
             'admin' => 1,
             'staff' => 5,
-            'user' => 9,
+            'user'  => 9,
         ];
 
         $item = Item::factory()->create();

--- a/tests/Feature/Http/Controllers/ItemController/Index/IndexMethodTest.php
+++ b/tests/Feature/Http/Controllers/ItemController/Index/IndexMethodTest.php
@@ -2,34 +2,17 @@
 
 namespace Tests\Feature\Http\Controllers\ItemController\Index;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
-use Tests\TestCase;
-use Faker\Factory as FakerFactory;
-use App\Models\Category;
-use App\Models\User;
-use App\Models\Item;
-use App\Models\Unit;
-use App\Models\Location;
-use App\Models\UsageStatus;
 use App\Models\AcquisitionMethod;
-use App\Models\Edithistory;
-use App\Models\Inspection;
-use App\Models\EditReason;
-use App\Models\RequestStatus;
-use App\Models\StockTransaction;
-use App\Services\ImageService;
+use App\Models\Category;
+use App\Models\Item;
+use App\Models\Location;
+use App\Models\Unit;
+use App\Models\UsageStatus;
+use App\Models\User;
+use Faker\Factory as FakerFactory;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Inertia\Testing\AssertableInertia as Assert;
-use Mockery;
-use App\Services\ManagementIdService;
-use Illuminate\Support\Facades\Auth;
-use Carbon\Carbon;
-use Illuminate\Database\Console\DumpCommand;
-use Illuminate\Testing\Fluent\AssertableJson;
-use Inertia\Inertia;
-use Illuminate\Http\UploadedFile;
-use Illuminate\Support\Facades\Session;
-
+use Tests\TestCase;
 
 class IndexMethodTest extends TestCase
 {
@@ -44,19 +27,18 @@ class IndexMethodTest extends TestCase
 
     protected function tearDown(): void
     {
-        // 子クラスでのクリーンアップ処理
         parent::tearDown();
     }
 
     /** @test */
-    function 備品一覧画面表示用のpaginateオブジェクトのデータを渡す()
+    public function 備品一覧画面表示用のpaginateオブジェクトのデータを渡す()
     {
         // リレーションのダミーデータを作成
         // $categories = Category::all(); all()は使えない
-        $categories = Category::factory()->count(11)->create();
-        $units = Unit::factory()->count(10)->create();
-        $usage_statuses = UsageStatus::factory()->count(2)->create();
-        $locations = Location::factory()->count(12)->create();
+        $categories         = Category::factory()->count(11)->create();
+        $units              = Unit::factory()->count(10)->create();
+        $usage_statuses     = UsageStatus::factory()->count(2)->create();
+        $locations          = Location::factory()->count(12)->create();
         $aquisition_methods = AcquisitionMethod::factory()->count(6)->create();
 
         // 各コレクションの要素数を出力
@@ -67,15 +49,15 @@ class IndexMethodTest extends TestCase
         echo 'Acquisition Methods count: ' . $aquisition_methods->count() . PHP_EOL;
 
         $items = Item::factory()->count(20)->create([
-            'management_id' => $this->faker->regexify('[A-Za-z0-9]{7}'),
+            'management_id'         => $this->faker->regexify('[A-Za-z0-9]{7}'),
             // 'name' => 'テストアイテム', // nameを上書きできる
-            'category_id' => $categories->random()->id,
-            'unit_id' => $units->random()->id,
-            'usage_status_id' => $usage_statuses->random()->id,
-            'location_of_use_id' => $locations->random()->id,
-            'storage_location_id' => $locations->random()->id,
+            'category_id'           => $categories->random()->id,
+            'unit_id'               => $units->random()->id,
+            'usage_status_id'       => $usage_statuses->random()->id,
+            'location_of_use_id'    => $locations->random()->id,
+            'storage_location_id'   => $locations->random()->id,
             'acquisition_method_id' => $aquisition_methods->random()->id,
-            'deleted_at' => null //ソフトデリートされていない
+            'deleted_at'            => null, //ソフトデリートされていない
         ]);
 
         // adminユーザーを作成
@@ -86,79 +68,79 @@ class IndexMethodTest extends TestCase
             ->assertOk();
         \Log::info('レスポンス: ' . $response->status()); // レスポンスのステータスコードをログに出力
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Index')
-            ->has('items.data', 20)
-            ->has('items.data', fn ($data) => $data
-                ->each(fn ($item)=> $item
-                    ->hasAll([
-                        'id',
-                        'management_id',
-                        'name',
-                        'category_id',
-                        'image1',
-                        'stock',
-                        'unit_id',
-                        'minimum_stock',
-                        'notification',
-                        'usage_status_id',
-                        'end_user',
-                        'location_of_use_id',
-                        'storage_location_id',
-                        'acquisition_method_id',
-                        'acquisition_source',
-                        'price',
-                        'date_of_acquisition',
-                        'manufacturer',
-                        'product_number',
-                        'remarks',
-                        'qrcode',
-                        'deleted_at',
-                        'created_at',
-                        'image_path1', //画像名から加工した画像パス
-                        'inspection_scheduled_date',
-                        'category',
-                        'unit',
-                        'usage_status',
-                        'location_of_use',
-                        'storage_location',
-                        'acquisition_method',
-                        'inspections',
-                        'disposal',
-                    ])
-                    ->has('category', fn ($category) => $category
-                        ->hasAll(['id', 'name', 'created_at', 'updated_at'])
-                    )
-                    ->has('unit', fn ($unit) => $unit
-                        ->hasAll(['id', 'name', 'created_at', 'updated_at'])
-                    )
-                    ->has('location_of_use', fn ($location) => $location
-                        ->hasAll(['id', 'name', 'created_at', 'updated_at'])
-                    )
-                    ->has('storage_location', fn ($location) => $location
-                        ->hasAll(['id', 'name', 'created_at', 'updated_at'])
-                    )
-                    ->has('acquisition_method', fn ($acquisition_method) => $acquisition_method
-                        ->hasAll(['id', 'name', 'created_at', 'updated_at'])
-                    )
-                    ->has('usage_status', fn ($usage_status) => $usage_status
-                        ->hasAll(['id', 'name', 'created_at', 'updated_at'])
-                    )
-                    
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Index')
+                ->has('items.data', 20)
+                ->has('items.data', fn($data) => $data
+                        ->each(fn($item) => $item
+                                ->hasAll([
+                                    'id',
+                                    'management_id',
+                                    'name',
+                                    'category_id',
+                                    'image1',
+                                    'stock',
+                                    'unit_id',
+                                    'minimum_stock',
+                                    'notification',
+                                    'usage_status_id',
+                                    'end_user',
+                                    'location_of_use_id',
+                                    'storage_location_id',
+                                    'acquisition_method_id',
+                                    'acquisition_source',
+                                    'price',
+                                    'date_of_acquisition',
+                                    'manufacturer',
+                                    'product_number',
+                                    'remarks',
+                                    'qrcode',
+                                    'deleted_at',
+                                    'created_at',
+                                    'image_path1', //画像名から加工した画像パス
+                                    'inspection_scheduled_date',
+                                    'category',
+                                    'unit',
+                                    'usage_status',
+                                    'location_of_use',
+                                    'storage_location',
+                                    'acquisition_method',
+                                    'inspections',
+                                    'disposal',
+                                ])
+                                ->has('category', fn($category) => $category
+                                        ->hasAll(['id', 'name', 'created_at', 'updated_at'])
+                                )
+                                ->has('unit', fn($unit) => $unit
+                                        ->hasAll(['id', 'name', 'created_at', 'updated_at'])
+                                )
+                                ->has('location_of_use', fn($location) => $location
+                                        ->hasAll(['id', 'name', 'created_at', 'updated_at'])
+                                )
+                                ->has('storage_location', fn($location) => $location
+                                        ->hasAll(['id', 'name', 'created_at', 'updated_at'])
+                                )
+                                ->has('acquisition_method', fn($acquisition_method) => $acquisition_method
+                                        ->hasAll(['id', 'name', 'created_at', 'updated_at'])
+                                )
+                                ->has('usage_status', fn($usage_status) => $usage_status
+                                        ->hasAll(['id', 'name', 'created_at', 'updated_at'])
+                                )
+
+                        )
                 )
-            )
         );
     }
 
     /** @test */
-    function 廃棄済みの備品一覧画面表示用のpaginateオブジェクトのデータを渡す()
+    public function 廃棄済みの備品一覧画面表示用のpaginateオブジェクトのデータを渡す()
     {
         // リレーションのダミーデータを作成
         // $categories = Category::all(); all()は使えない
-        $categories = Category::factory()->count(11)->create();
-        $units = Unit::factory()->count(10)->create();
-        $usage_statuses = UsageStatus::factory()->count(2)->create();
-        $locations = Location::factory()->count(12)->create();
+        $categories         = Category::factory()->count(11)->create();
+        $units              = Unit::factory()->count(10)->create();
+        $usage_statuses     = UsageStatus::factory()->count(2)->create();
+        $locations          = Location::factory()->count(12)->create();
         $aquisition_methods = AcquisitionMethod::factory()->count(6)->create();
 
         // 各コレクションの要素数を出力
@@ -169,15 +151,15 @@ class IndexMethodTest extends TestCase
         echo 'Acquisition Methods count: ' . $aquisition_methods->count() . PHP_EOL;
 
         $items = Item::factory()->count(20)->create([
-            'management_id' => $this->faker->regexify('[A-Za-z0-9]{7}'),
+            'management_id'         => $this->faker->regexify('[A-Za-z0-9]{7}'),
             // 'name' => 'テストアイテム', // nameを上書きできる
-            'category_id' => $categories->random()->id,
-            'unit_id' => $units->random()->id,
-            'usage_status_id' => $usage_statuses->random()->id,
-            'location_of_use_id' => $locations->random()->id,
-            'storage_location_id' => $locations->random()->id,
+            'category_id'           => $categories->random()->id,
+            'unit_id'               => $units->random()->id,
+            'usage_status_id'       => $usage_statuses->random()->id,
+            'location_of_use_id'    => $locations->random()->id,
+            'storage_location_id'   => $locations->random()->id,
             'acquisition_method_id' => $aquisition_methods->random()->id,
-            'deleted_at' => $this->faker->date() //ソフトデリートされた（廃棄された）
+            'deleted_at'            => $this->faker->date(), //ソフトデリートされた（廃棄された）
         ]);
 
         // adminユーザーを作成
@@ -188,67 +170,67 @@ class IndexMethodTest extends TestCase
             ->assertOk();
         \Log::info('レスポンス: ' . $response->status()); // レスポンスのステータスコードをログに出力
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Index')
-            ->has('items.data', 20)
-            ->has('items.data', fn ($data) => $data
-                ->each(fn ($item)=> $item
-                    ->hasAll([
-                        'id',
-                        'management_id',
-                        'name',
-                        'category_id',
-                        'image1',
-                        'stock',
-                        'unit_id',
-                        'minimum_stock',
-                        'notification',
-                        'usage_status_id',
-                        'end_user',
-                        'location_of_use_id',
-                        'storage_location_id',
-                        'acquisition_method_id',
-                        'acquisition_source',
-                        'price',
-                        'date_of_acquisition',
-                        'manufacturer',
-                        'product_number',
-                        'remarks',
-                        'qrcode',
-                        'deleted_at',
-                        'created_at',
-                        'image_path1', //画像名から加工した画像パス
-                        'inspection_scheduled_date',
-                        'category',
-                        'unit',
-                        'usage_status',
-                        'location_of_use',
-                        'storage_location',
-                        'acquisition_method',
-                        'inspections',
-                        'disposal',
-                    ])
-                    ->where('deleted_at', fn ($deletedAt) => (bool)strtotime($deletedAt)) // `deleted_at` が有効な日付であることを確認
-                    ->has('category', fn ($category) => $category
-                        ->hasAll(['id', 'name', 'created_at', 'updated_at'])
-                    )
-                    ->has('unit', fn ($unit) => $unit
-                        ->hasAll(['id', 'name', 'created_at', 'updated_at'])
-                    )
-                    ->has('location_of_use', fn ($location) => $location
-                        ->hasAll(['id', 'name', 'created_at', 'updated_at'])
-                    )
-                    ->has('storage_location', fn ($location) => $location
-                        ->hasAll(['id', 'name', 'created_at', 'updated_at'])
-                    )
-                    ->has('acquisition_method', fn ($acquisition_method) => $acquisition_method
-                        ->hasAll(['id', 'name', 'created_at', 'updated_at'])
-                    )
-                    ->has('usage_status', fn ($usage_status) => $usage_status
-                        ->hasAll(['id', 'name', 'created_at', 'updated_at'])
-                    )
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Index')
+                ->has('items.data', 20)
+                ->has('items.data', fn($data) => $data
+                        ->each(fn($item) => $item
+                                ->hasAll([
+                                    'id',
+                                    'management_id',
+                                    'name',
+                                    'category_id',
+                                    'image1',
+                                    'stock',
+                                    'unit_id',
+                                    'minimum_stock',
+                                    'notification',
+                                    'usage_status_id',
+                                    'end_user',
+                                    'location_of_use_id',
+                                    'storage_location_id',
+                                    'acquisition_method_id',
+                                    'acquisition_source',
+                                    'price',
+                                    'date_of_acquisition',
+                                    'manufacturer',
+                                    'product_number',
+                                    'remarks',
+                                    'qrcode',
+                                    'deleted_at',
+                                    'created_at',
+                                    'image_path1', //画像名から加工した画像パス
+                                    'inspection_scheduled_date',
+                                    'category',
+                                    'unit',
+                                    'usage_status',
+                                    'location_of_use',
+                                    'storage_location',
+                                    'acquisition_method',
+                                    'inspections',
+                                    'disposal',
+                                ])
+                                ->where('deleted_at', fn($deletedAt) => (bool) strtotime($deletedAt)) // `deleted_at` が有効な日付であることを確認
+                                ->has('category', fn($category) => $category
+                                        ->hasAll(['id', 'name', 'created_at', 'updated_at'])
+                                )
+                                ->has('unit', fn($unit) => $unit
+                                        ->hasAll(['id', 'name', 'created_at', 'updated_at'])
+                                )
+                                ->has('location_of_use', fn($location) => $location
+                                        ->hasAll(['id', 'name', 'created_at', 'updated_at'])
+                                )
+                                ->has('storage_location', fn($location) => $location
+                                        ->hasAll(['id', 'name', 'created_at', 'updated_at'])
+                                )
+                                ->has('acquisition_method', fn($acquisition_method) => $acquisition_method
+                                        ->hasAll(['id', 'name', 'created_at', 'updated_at'])
+                                )
+                                ->has('usage_status', fn($usage_status) => $usage_status
+                                        ->hasAll(['id', 'name', 'created_at', 'updated_at'])
+                                )
+                        )
                 )
-            )
         );
     }
 }

--- a/tests/Feature/Http/Controllers/ItemController/Show/ShowMethodTest.php
+++ b/tests/Feature/Http/Controllers/ItemController/Show/ShowMethodTest.php
@@ -2,22 +2,18 @@
 
 namespace Tests\Feature\Http\Controllers\ItemController\Show;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
-use Tests\TestCase;
-use Faker\Factory as FakerFactory;
-use App\Models\User;
-use App\Models\Item;
-use App\Models\Unit;
-use App\Models\Category;
-use App\Models\Location;
-use App\Models\UsageStatus;
 use App\Models\AcquisitionMethod;
+use App\Models\Category;
 use App\Models\Inspection;
-use App\Models\Edithistory;
-use App\Models\EditReason;
-use App\Models\RequestStatus;
+use App\Models\Item;
+use App\Models\Location;
+use App\Models\Unit;
+use App\Models\UsageStatus;
+use App\Models\User;
+use Faker\Factory as FakerFactory;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Inertia\Testing\AssertableInertia as Assert;
+use Tests\TestCase;
 
 class ShowMethodTest extends TestCase
 {
@@ -29,48 +25,46 @@ class ShowMethodTest extends TestCase
 
         $this->faker = FakerFactory::create();
     }
-    
+
     protected function tearDown(): void
     {
-        // 子クラスでのクリーンアップ処理
         parent::tearDown();
     }
 
     /** @test */
-    function 備品の詳細画面を開く()
+    public function 備品の詳細画面を開く()
     {
-        $categories = Category::factory()->count(11)->create();
-        $units = Unit::factory()->count(10)->create();
-        $usage_statuses = UsageStatus::factory()->count(2)->create();
-        $locations = Location::factory()->count(12)->create();
+        $categories         = Category::factory()->count(11)->create();
+        $units              = Unit::factory()->count(10)->create();
+        $usage_statuses     = UsageStatus::factory()->count(2)->create();
+        $locations          = Location::factory()->count(12)->create();
         $aquisition_methods = AcquisitionMethod::factory()->count(6)->create();
-        
-        $item = Item::factory()->create([
-            'management_id' => $this->faker->regexify('[A-Za-z0-9]{7}'),
-            // 'name' => 'テストアイテム', // nameを上書きできる
-            'category_id' => $categories->random()->id,
-            'unit_id' => $units->random()->id,
-            'usage_status_id' => $usage_statuses->random()->id,
-            'location_of_use_id' => $locations->random()->id,
-            'storage_location_id' => $locations->random()->id,
-            'acquisition_method_id' => $aquisition_methods->random()->id
-        ]);
 
+        $item = Item::factory()->create([
+            'management_id'         => $this->faker->regexify('[A-Za-z0-9]{7}'),
+            // 'name' => 'テストアイテム', // nameを上書きできる
+            'category_id'           => $categories->random()->id,
+            'unit_id'               => $units->random()->id,
+            'usage_status_id'       => $usage_statuses->random()->id,
+            'location_of_use_id'    => $locations->random()->id,
+            'storage_location_id'   => $locations->random()->id,
+            'acquisition_method_id' => $aquisition_methods->random()->id,
+        ]);
 
         $uncompleted_inspection = Inspection::withoutEvents(function () use ($item) {
             return Inspection::factory()->create([
                 'item_id' => $item->id,
-                'status' => false, // 点検予定
+                'status'  => false, // 点検予定
             ]);
         });
-        
+
         $last_completed_inspection = Inspection::withoutEvents(function () use ($item) {
             return Inspection::factory()->create([
                 'item_id' => $item->id,
-                'status' => true, // 点検実行済み
+                'status'  => true, // 点検実行済み
             ]);
         });
-        
+
         $user = User::factory()->role(1)->create();
         $this->actingAs($user);
 
@@ -78,17 +72,17 @@ class ShowMethodTest extends TestCase
         $response = $this->get('/items/' . $item->id)
             ->assertOk();
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Show') // Vueコンポーネント
-            ->has('item', fn (Assert $page) => $page
-                ->where('id', $item->id)
-                ->etc()
-            )
-            ->where('uncompleted_inspection.inspection_date', $uncompleted_inspection->inspection_date->format('Y-m-d')) //日付は文字列の形式に変換、ダミーデータとの整合性
-            ->where('uncompleted_inspection.inspection_scheduled_date', $uncompleted_inspection->inspection_scheduled_date->format('Y-m-d'))
-            ->where('last_completed_inspection.inspection_date', $last_completed_inspection->inspection_date->format('Y-m-d'))
-            ->where('last_completed_inspection.inspection_scheduled_date', $last_completed_inspection->inspection_scheduled_date->format('Y-m-d'))
-            ->where('userName', $user->name)
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Show') // Vueコンポーネント
+                ->has('item', fn(Assert $page) => $page
+                        ->where('id', $item->id)
+                        ->etc()
+                )
+                ->where('uncompleted_inspection.inspection_date', $uncompleted_inspection->inspection_date->format('Y-m-d')) //日付は文字列の形式に変換、ダミーデータとの整合性
+                ->where('uncompleted_inspection.inspection_scheduled_date', $uncompleted_inspection->inspection_scheduled_date->format('Y-m-d'))
+                ->where('last_completed_inspection.inspection_date', $last_completed_inspection->inspection_date->format('Y-m-d'))
+                ->where('last_completed_inspection.inspection_scheduled_date', $last_completed_inspection->inspection_scheduled_date->format('Y-m-d'))
+                ->where('userName', $user->name)
         );
     }
 }

--- a/tests/Feature/Http/Controllers/ItemController/Store/StoreMethodTest.php
+++ b/tests/Feature/Http/Controllers/ItemController/Store/StoreMethodTest.php
@@ -2,39 +2,23 @@
 
 namespace Tests\Feature\Http\Controllers\ItemController\Store;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
-use Tests\TestCase;
-use App\Models\User;
-use App\Models\Item;
-use App\Models\Unit;
-use App\Models\Category;
-use App\Models\Location;
-use App\Models\UsageStatus;
 use App\Models\AcquisitionMethod;
-use App\Models\Edithistory;
-use App\Models\Inspection;
-use App\Models\EditReason;
-use App\Models\RequestStatus;
-use App\Models\StockTransaction;
+use App\Models\Category;
+use App\Models\Item;
+use App\Models\Location;
+use App\Models\Unit;
+use App\Models\UsageStatus;
+use App\Models\User;
 use App\Services\ImageService;
-use Faker\Factory as FakerFactory;
-use Inertia\Testing\AssertableInertia as Assert;
-use Mockery;
 use App\Services\ManagementIdService;
 use App\Services\QrCodeService;
-use Illuminate\Support\Facades\Auth;
-use Carbon\Carbon;
-use Illuminate\Database\Console\DumpCommand;
-use Illuminate\Testing\Fluent\AssertableJson;
-use Inertia\Inertia;
+use Faker\Factory as FakerFactory;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\UploadedFile;
-use Illuminate\Support\Facades\Storage;
-use Intervention\Image\ImageManager;
-// use Intervention\Image\Drivers\Gd\Driver;
-use Intervention\Image\Drivers\Imagick\Driver;
-use Illuminate\Support\Facades\Session;
 use Illuminate\Support\Facades\App;
+use Illuminate\Support\Facades\Auth;
+use Mockery;
+use Tests\TestCase;
 
 class StoreMethodTest extends TestCase
 {
@@ -68,7 +52,7 @@ class StoreMethodTest extends TestCase
     }
 
     /** @test */
-    function 備品新規登録画面で備品を登録できる、消耗品の時()
+    public function 備品新規登録画面で備品を登録できる、消耗品の時()
     {
         // 備品が新規作成された裏でItemObserverによってedithistoriesテーブルにもデータが保存される
         // CI環境でのQrCodeServiceのモック化
@@ -78,21 +62,21 @@ class StoreMethodTest extends TestCase
                 ->once()
                 ->with(Mockery::type(Item::class))
                 ->andReturn([
-                    'labelNameToStore' => 'mocked_label.jpg',
-                    'qrCodeNameToStore' => 'mocked_qrcode.png'
+                    'labelNameToStore'  => 'mocked_label.jpg',
+                    'qrCodeNameToStore' => 'mocked_qrcode.png',
                 ]);
             $this->app->instance(QrCodeService::class, $mock);
         }
 
         $category = Category::factory()->create([
-            'id' => 1,
-            'name' => '消耗品'
+            'id'   => 1,
+            'name' => '消耗品',
         ]);
-        $categories = Category::factory()->count(10)->create(); //残りのカテゴリ
-        $categories = $categories->concat($category); //全てのカテゴリ
-        $units = Unit::factory()->count(10)->create();
-        $usage_statuses = UsageStatus::factory()->count(2)->create();
-        $locations = Location::factory()->count(12)->create();
+        $categories         = Category::factory()->count(10)->create(); //残りのカテゴリ
+        $categories         = $categories->concat($category);           //全てのカテゴリ
+        $units              = Unit::factory()->count(10)->create();
+        $usage_statuses     = UsageStatus::factory()->count(2)->create();
+        $locations          = Location::factory()->count(12)->create();
         $aquisition_methods = AcquisitionMethod::factory()->count(6)->create();
 
         $user = User::factory()->role(1)->create(); //admin権限
@@ -101,148 +85,147 @@ class StoreMethodTest extends TestCase
         // モックを作成
         $mock = Mockery::mock(ManagementIdService::class);
         $mock->shouldReceive('generate')
-                ->once()
-                ->with($category->id)
-                ->andReturn('CO-1111');
+            ->once()
+            ->with($category->id)
+            ->andReturn('CO-1111');
         // サービスコンテナで呼び出す
         $this->instance(ManagementIdService::class, $mock);
 
         $validData = [
-            'name' => 'ペーパータオル',
-            'category_id' => $category->id,
-            'image_file' => $this->fakeImage,
-            'image1' => null,
-            'stock' => 10,
-            'unit_id' => $units->first()->id,
-            'minimum_stock' => 2,
-            'notification' => true,
-            'usage_status_id' => $usage_statuses->first()->id,
-            'end_user' => '山田',
-            'location_of_use_id' => $locations->first()->id,
-            'storage_location_id' => $locations->last()->id,
-            'acquisition_method_id' => $aquisition_methods->first()->id,
-            'acquisition_source' => 'Amazon',
-            'price' => 500,
-            'date_of_acquisition' => '2024-09-03',
-            'manufacturer' => null,
-            'product_number' => null,
-            'remarks' => 'テストコードです',
-            'qrcode' => null,
+            'name'                      => 'ペーパータオル',
+            'category_id'               => $category->id,
+            'image_file'                => $this->fakeImage,
+            'image1'                    => null,
+            'stock'                     => 10,
+            'unit_id'                   => $units->first()->id,
+            'minimum_stock'             => 2,
+            'notification'              => true,
+            'usage_status_id'           => $usage_statuses->first()->id,
+            'end_user'                  => '山田',
+            'location_of_use_id'        => $locations->first()->id,
+            'storage_location_id'       => $locations->last()->id,
+            'acquisition_method_id'     => $aquisition_methods->first()->id,
+            'acquisition_source'        => 'Amazon',
+            'price'                     => 500,
+            'date_of_acquisition'       => '2024-09-03',
+            'manufacturer'              => null,
+            'product_number'            => null,
+            'remarks'                   => 'テストコードです',
+            'qrcode'                    => null,
             'inspection_scheduled_date' => '2024-09-10',
-            'disposal_scheduled_date' => '2024-09-20'
+            'disposal_scheduled_date'   => '2024-09-20',
         ];
 
         $response = $this->from('items/create')
             ->post(route('items.store'), $validData);
-        
+
         // dd($response->status()); // ステータスコード
         // dd($response->getContent()); // レスポンスの内容を確認
-        
+
         $response->assertStatus(302);
         \Log::debug('$response', ['context' => $response]);
         $response->assertRedirect('items');
 
         $this->assertDatabaseHas('items', [
-            'management_id' => 'CO-1111',
-            'name' => 'ペーパータオル',
-            'category_id' => $category->id,
-            'image1' => 'mocked_image.jpg',
-            'stock' => 10,
-            'unit_id' => $units->first()->id,
-            'minimum_stock' => 2,
-            'notification' => 1, //true
-            'usage_status_id' => $usage_statuses->first()->id,
-            'end_user' => '山田',
-            'location_of_use_id' => $locations->first()->id,
-            'storage_location_id' => $locations->last()->id,
+            'management_id'         => 'CO-1111',
+            'name'                  => 'ペーパータオル',
+            'category_id'           => $category->id,
+            'image1'                => 'mocked_image.jpg',
+            'stock'                 => 10,
+            'unit_id'               => $units->first()->id,
+            'minimum_stock'         => 2,
+            'notification'          => 1, //true
+            'usage_status_id'       => $usage_statuses->first()->id,
+            'end_user'              => '山田',
+            'location_of_use_id'    => $locations->first()->id,
+            'storage_location_id'   => $locations->last()->id,
             'acquisition_method_id' => $aquisition_methods->first()->id,
-            'acquisition_source' => 'Amazon',
-            'price' => 500,
-            'date_of_acquisition' => '2024-09-03',
-            'manufacturer' => null,
-            'product_number' => null,
-            'remarks' => 'テストコードです',
+            'acquisition_source'    => 'Amazon',
+            'price'                 => 500,
+            'date_of_acquisition'   => '2024-09-03',
+            'manufacturer'          => null,
+            'product_number'        => null,
+            'remarks'               => 'テストコードです',
             // 'qrcode' => null, // QRコードは実際には生成される
         ]);
 
         $item = Item::where('management_id', 'CO-1111')->first();
         dump(Item::where('management_id', 'CO-1111')->first()->id);
 
-
         // inspectionsテーブルに保存されているか確認
         $this->assertDatabaseHas('inspections', [
-            'item_id' => $item->id,
-            'inspection_scheduled_date' =>  '2024-09-10',
+            'item_id'                   => $item->id,
+            'inspection_scheduled_date' => '2024-09-10',
         ]);
 
         // disposalsテーブルに保存されているか確認
         $this->assertDatabaseHas('disposals', [
-            'item_id' => $item->id,
+            'item_id'                 => $item->id,
             'disposal_scheduled_date' => '2024-09-20',
         ]);
 
         // その後ItemObserverによるedithistoriesテーブルへの保存をアサ―ト
         $this->assertDatabaseHas('edithistories', [
-            'edit_mode' => 'normal',
+            'edit_mode'      => 'normal',
             'operation_type' => 'store',
-            'item_id' => $item->id,
-            'edited_field' => null,
-            'old_value' => null,
-            'new_value' => null,
-            'edit_user' => Auth::user()->name,
+            'item_id'        => $item->id,
+            'edited_field'   => null,
+            'old_value'      => null,
+            'new_value'      => null,
+            'edit_user'      => Auth::user()->name,
         ]);
     }
 
     /** @test */
-    function 備品新規登録画面で備品を登録できる、消耗品以外の時()
+    public function 備品新規登録画面で備品を登録できる、消耗品以外の時()
     {
         // 備品が新規作成された裏でItemObserverによってedithistoriesテーブルにもデータが保存される
 
         $category = Category::factory()->create([
-            'id' => 2,
-            'name' => 'IT機器'
+            'id'   => 2,
+            'name' => 'IT機器',
         ]);
-        $categories = Category::factory()->count(10)->create(); //残りのカテゴリ
-        $categories = $categories->concat($category); //全てのカテゴリ
-        $units = Unit::factory()->count(10)->create();
-        $usage_statuses = UsageStatus::factory()->count(2)->create();
-        $locations = Location::factory()->count(12)->create();
+        $categories         = Category::factory()->count(10)->create(); //残りのカテゴリ
+        $categories         = $categories->concat($category);           //全てのカテゴリ
+        $units              = Unit::factory()->count(10)->create();
+        $usage_statuses     = UsageStatus::factory()->count(2)->create();
+        $locations          = Location::factory()->count(12)->create();
         $aquisition_methods = AcquisitionMethod::factory()->count(6)->create();
 
         $user = User::factory()->role(1)->create(); //admin権限
-        $this->actingAs($user);   
+        $this->actingAs($user);
 
         // モックを作成
         $mock = Mockery::mock(ManagementIdService::class);
         $mock->shouldReceive('generate')
-                ->once()
-                ->with($category->id)
-                ->andReturn('CO-1111');
+            ->once()
+            ->with($category->id)
+            ->andReturn('CO-1111');
         // サービスコンテナで呼び出す
         $this->instance(ManagementIdService::class, $mock);
 
         $validData = [
-            'name' => 'ペーパータオル',
-            'category_id' => $category->id,
-            'image_file' => $this->fakeImage,
-            'stock' => 10,
-            'unit_id' => $units->first()->id,
-            'minimum_stock' => 2,
-            'notification' => true,
-            'usage_status_id' => $usage_statuses->first()->id,
-            'end_user' => '山田',
-            'location_of_use_id' => $locations->first()->id,
-            'storage_location_id' => $locations->last()->id,
-            'acquisition_method_id' => $aquisition_methods->first()->id,
-            'acquisition_source' => 'Amazon',
-            'price' => 500,
-            'date_of_acquisition' => '2024-09-03',
-            'manufacturer' => null,
-            'product_number' => null,
-            'remarks' => 'テストコードです',
-            'qrcode' => null,
+            'name'                      => 'ペーパータオル',
+            'category_id'               => $category->id,
+            'image_file'                => $this->fakeImage,
+            'stock'                     => 10,
+            'unit_id'                   => $units->first()->id,
+            'minimum_stock'             => 2,
+            'notification'              => true,
+            'usage_status_id'           => $usage_statuses->first()->id,
+            'end_user'                  => '山田',
+            'location_of_use_id'        => $locations->first()->id,
+            'storage_location_id'       => $locations->last()->id,
+            'acquisition_method_id'     => $aquisition_methods->first()->id,
+            'acquisition_source'        => 'Amazon',
+            'price'                     => 500,
+            'date_of_acquisition'       => '2024-09-03',
+            'manufacturer'              => null,
+            'product_number'            => null,
+            'remarks'                   => 'テストコードです',
+            'qrcode'                    => null,
             'inspection_scheduled_date' => '2024-09-10',
-            'disposal_scheduled_date' => '2024-09-20'
+            'disposal_scheduled_date'   => '2024-09-20',
         ];
 
         $response = $this->from('items/create')
@@ -251,26 +234,26 @@ class StoreMethodTest extends TestCase
         $response->assertRedirect('items');
 
         $this->assertDatabaseHas('items', [
-            'management_id' => 'CO-1111',
-            'name' => 'ペーパータオル',
-            'category_id' => $category->id,
-            'image1' => 'mocked_image.jpg',
-            'stock' => 10,
-            'unit_id' => $units->first()->id,
-            'minimum_stock' => null, //IT機器なのでminimum_stockはnull
-            'notification' => true,
-            'usage_status_id' => $usage_statuses->first()->id,
-            'end_user' => '山田',
-            'location_of_use_id' => $locations->first()->id,
-            'storage_location_id' => $locations->last()->id,
+            'management_id'         => 'CO-1111',
+            'name'                  => 'ペーパータオル',
+            'category_id'           => $category->id,
+            'image1'                => 'mocked_image.jpg',
+            'stock'                 => 10,
+            'unit_id'               => $units->first()->id,
+            'minimum_stock'         => null, //IT機器なのでminimum_stockはnull
+            'notification'          => true,
+            'usage_status_id'       => $usage_statuses->first()->id,
+            'end_user'              => '山田',
+            'location_of_use_id'    => $locations->first()->id,
+            'storage_location_id'   => $locations->last()->id,
             'acquisition_method_id' => $aquisition_methods->first()->id,
-            'acquisition_source' => 'Amazon',
-            'price' => 500,
-            'date_of_acquisition' => '2024-09-03',
-            'manufacturer' => null,
-            'product_number' => null,
-            'remarks' => 'テストコードです',
-            'qrcode' => null,
+            'acquisition_source'    => 'Amazon',
+            'price'                 => 500,
+            'date_of_acquisition'   => '2024-09-03',
+            'manufacturer'          => null,
+            'product_number'        => null,
+            'remarks'               => 'テストコードです',
+            'qrcode'                => null,
         ]);
 
         $item = Item::where('management_id', 'CO-1111')->first();
@@ -278,25 +261,25 @@ class StoreMethodTest extends TestCase
 
         // inspectionsテーブルに保存されているか確認
         $this->assertDatabaseHas('inspections', [
-            'item_id' => $item->id,
-            'inspection_scheduled_date' =>  '2024-09-10',
+            'item_id'                   => $item->id,
+            'inspection_scheduled_date' => '2024-09-10',
         ]);
 
         // disposalsテーブルに保存されているか確認
         $this->assertDatabaseHas('disposals', [
-            'item_id' => $item->id,
+            'item_id'                 => $item->id,
             'disposal_scheduled_date' => '2024-09-20',
         ]);
 
         // その後ItemObserverによるedithistoriesテーブルへの保存をテスト
         $this->assertDatabaseHas('edithistories', [
-            'edit_mode' => 'normal',
+            'edit_mode'      => 'normal',
             'operation_type' => 'store',
-            'item_id' => $item->id,
-            'edited_field' => null,
-            'old_value' => null,
-            'new_value' => null,
-            'edit_user' => Auth::user()->name,
+            'item_id'        => $item->id,
+            'edited_field'   => null,
+            'old_value'      => null,
+            'new_value'      => null,
+            'edit_user'      => Auth::user()->name,
         ]);
     }
 }

--- a/tests/Feature/Http/Controllers/ItemController/Store/StoreValidationTest.php
+++ b/tests/Feature/Http/Controllers/ItemController/Store/StoreValidationTest.php
@@ -2,39 +2,21 @@
 
 namespace Tests\Feature\Http\Controllers\ItemController\Store;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
-use Tests\TestCase;
-use App\Models\User;
-use App\Models\Item;
-use App\Models\Unit;
-use App\Models\Category;
-use App\Models\Location;
-use App\Models\UsageStatus;
 use App\Models\AcquisitionMethod;
-use App\Models\Edithistory;
-use App\Models\Inspection;
-use App\Models\EditReason;
-use App\Models\RequestStatus;
-use App\Models\StockTransaction;
-use App\Services\ImageService;
+use App\Models\Category;
+use App\Models\Item;
+use App\Models\Location;
+use App\Models\Unit;
+use App\Models\UsageStatus;
+use App\Models\User;
+use App\Services\QrCodeService;
+use Carbon\Carbon;
 use Faker\Factory as FakerFactory;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\App;
 use Inertia\Testing\AssertableInertia as Assert;
 use Mockery;
-use App\Services\QrCodeService;
-use App\Services\ManagementIdService;
-use Illuminate\Support\Facades\Auth;
-use Carbon\Carbon;
-use Illuminate\Database\Console\DumpCommand;
-use Illuminate\Testing\Fluent\AssertableJson;
-use Inertia\Inertia;
-use Illuminate\Http\UploadedFile;
-use Illuminate\Support\Facades\Storage;
-use Intervention\Image\ImageManager;
-// use Intervention\Image\Drivers\Gd\Driver;
-use Intervention\Image\Drivers\Imagick\Driver;
-use Illuminate\Support\Facades\Session;
-use Illuminate\Support\Facades\App;
+use Tests\TestCase;
 
 class StoreValidationTest extends TestCase
 {
@@ -50,59 +32,57 @@ class StoreValidationTest extends TestCase
 
     protected function tearDown(): void
     {
-        // 子クラスでのクリーンアップ処理
         parent::tearDown();
     }
 
     // 新規登録のnameのバリデーションのテスト（データプロバイダを使用）
     /**
      * @dataProvider nameValidationProvider
-    * @test
-    */
+     * @test
+     */
     public function 備品新規登録バリデーションname($data)
     {
         $user = User::factory()->role(1)->create();
         $this->actingAs($user);
 
-        $url = 'items';
+        $url      = 'items';
         $response = $this->from('items/create')->post($url, $data);
         $response->assertRedirect('items/create'); //URLにリダイレクト
         $response->assertStatus(302);
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Create')
-            ->when($data['expectedError'] !== null, fn ($page) => $page
-                ->has('errors.name')
-                ->where('errors.name', $data['expectedError'])
-            )
-            ->when($data['expectedError'] === null, fn ($page) => $page
-                ->missing('errors.name')
-            )
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Create')
+                ->when($data['expectedError'] !== null, fn($page) => $page
+                        ->has('errors.name')
+                        ->where('errors.name', $data['expectedError'])
+                )
+                ->when($data['expectedError'] === null, fn($page) => $page
+                        ->missing('errors.name')
+                )
         );
     }
-    
+
     public static function nameValidationProvider()
     {
         return [
-            'nameが空文字の時はエラーメッセージが出る' => [
-                ['name' => '', 'expectedError' => '名前は必ず指定してください。']
+            'nameが空文字の時はエラーメッセージが出る'        => [
+                ['name' => '', 'expectedError' => '名前は必ず指定してください。'],
             ],
             'nameが1文字以下の時はエラーメッセージが出ない' => [
-                ['name' => str_repeat('あ', 1), 'expectedError' => null]
+                ['name' => str_repeat('あ', 1), 'expectedError' => null],
             ],
-            'nameが41文字の時はエラーメッセージが出る' => [
-                ['name' => str_repeat('あ', 41), 'expectedError' => '名前は、40文字以下で指定してください。']
+            'nameが41文字の時はエラーメッセージが出る'         => [
+                ['name' => str_repeat('あ', 41), 'expectedError' => '名前は、40文字以下で指定してください。'],
             ],
-            'nameが40文字の時はエラーメッセージが出ない' => [
-                ['name' => str_repeat('あ', 40), 'expectedError' => null]
+            'nameが40文字の時はエラーメッセージが出ない'      => [
+                ['name' => str_repeat('あ', 40), 'expectedError' => null],
             ],
         ];
     }
-    
 
-    // 新規登録のcategory_idのバリデーションのテスト    
+    // 新規登録のcategory_idのバリデーションのテスト
     /** @test */
     public function 備品新規登録バリデーションcategoryIdが最小値より小さい無効値()
     {
@@ -118,11 +98,11 @@ class StoreValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Create')
-            ->has('errors.category_id')
-            ->where('errors.category_id', '選択されたカテゴリは正しくありません。')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Create')
+                ->has('errors.category_id')
+                ->where('errors.category_id', '選択されたカテゴリは正しくありません。')
+                // ->dump()
         );
     }
 
@@ -141,10 +121,10 @@ class StoreValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Create')
-            ->missing('errors.category_id')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Create')
+                ->missing('errors.category_id')
+                // ->dump()
         );
     }
 
@@ -163,10 +143,10 @@ class StoreValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Create')
-            ->missing('errors.category_id')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Create')
+                ->missing('errors.category_id')
+                // ->dump()
         );
     }
 
@@ -185,14 +165,13 @@ class StoreValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Create')
-            ->has('errors.category_id')
-            ->where('errors.category_id', '選択されたカテゴリは正しくありません。')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Create')
+                ->has('errors.category_id')
+                ->where('errors.category_id', '選択されたカテゴリは正しくありません。')
+                // ->dump()
         );
     }
-
 
     // 新規登録のstockのバリデーションのテスト
     /** @test */
@@ -207,11 +186,11 @@ class StoreValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Create')
-            ->has('errors.stock')
-            ->where('errors.stock', '在庫数には、0以上の数字を指定してください。')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Create')
+                ->has('errors.stock')
+                ->where('errors.stock', '在庫数には、0以上の数字を指定してください。')
+                // ->dump()
         );
     }
 
@@ -227,10 +206,10 @@ class StoreValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Create')
-            ->missing('errors.stock')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Create')
+                ->missing('errors.stock')
+                // ->dump()
         );
     }
 
@@ -246,10 +225,10 @@ class StoreValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Create')
-            ->missing('errors.stock')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Create')
+                ->missing('errors.stock')
+                // ->dump()
         );
     }
 
@@ -265,14 +244,13 @@ class StoreValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Create')
-            ->has('errors.stock')
-            ->where('errors.stock', '在庫数には、200以下の数字を指定してください。')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Create')
+                ->has('errors.stock')
+                ->where('errors.stock', '在庫数には、200以下の数字を指定してください。')
+                // ->dump()
         );
     }
-
 
     // カテゴリが消耗品以外の時、minimum_stockがnullで保存されることをテスト
     /** @test */
@@ -285,8 +263,8 @@ class StoreValidationTest extends TestCase
                 ->once()
                 ->with(Mockery::type(Item::class))
                 ->andReturn([
-                    'labelNameToStore' => 'mocked_label.jpg',
-                    'qrCodeNameToStore' => 'mocked_qrcode.png'
+                    'labelNameToStore'  => 'mocked_label.jpg',
+                    'qrCodeNameToStore' => 'mocked_qrcode.png',
                 ]);
             $this->app->instance(QrCodeService::class, $mock);
         }
@@ -294,12 +272,12 @@ class StoreValidationTest extends TestCase
         // 世界を構築
         // $categories = Category::factory()->count(11)->create();
         $category = Category::factory()->create([
-            'id' => 1,
-            'name' => '消耗品'
+            'id'   => 1,
+            'name' => '消耗品',
         ]);
-        $units = Unit::factory()->count(10)->create();
-        $usage_statuses = UsageStatus::factory()->count(2)->create();
-        $locations = Location::factory()->count(12)->create();
+        $units              = Unit::factory()->count(10)->create();
+        $usage_statuses     = UsageStatus::factory()->count(2)->create();
+        $locations          = Location::factory()->count(12)->create();
         $aquisition_methods = AcquisitionMethod::factory()->count(6)->create();
 
         $user = User::factory()->role(1)->create();
@@ -307,35 +285,35 @@ class StoreValidationTest extends TestCase
 
         // 適切に保存されるデータでカテゴリが消耗品(catgery_id=1)の時
         $response = $this->from('items/create')->post('items', [
-            'name' => 'ペーパータオル',
-            'category_id' => $category->id,
-            'image1' => null,
-            'stock' => 10,
-            'unit_id' => $units->first()->id,
-            'minimum_stock' => 2,
-            'notification' => true,
-            'usage_status_id' => $usage_statuses->first()->id,
-            'end_user' => '山田',
-            'location_of_use_id' => $locations->first()->id,
-            'storage_location_id' => $locations->first()->id,
-            'acquisition_method_id' => $aquisition_methods->first()->id,
-            'acquisition_source' => 'Amazon',
-            'price' => 500,
-            'date_of_acquisition' => '2024-09-03',
-            'manufacturer' => null,
-            'product_number' => null,
-            'remarks' => 'テストコードです',
-            'qrcode' => null,
+            'name'                      => 'ペーパータオル',
+            'category_id'               => $category->id,
+            'image1'                    => null,
+            'stock'                     => 10,
+            'unit_id'                   => $units->first()->id,
+            'minimum_stock'             => 2,
+            'notification'              => true,
+            'usage_status_id'           => $usage_statuses->first()->id,
+            'end_user'                  => '山田',
+            'location_of_use_id'        => $locations->first()->id,
+            'storage_location_id'       => $locations->first()->id,
+            'acquisition_method_id'     => $aquisition_methods->first()->id,
+            'acquisition_source'        => 'Amazon',
+            'price'                     => 500,
+            'date_of_acquisition'       => '2024-09-03',
+            'manufacturer'              => null,
+            'product_number'            => null,
+            'remarks'                   => 'テストコードです',
+            'qrcode'                    => null,
             'inspection_scheduled_date' => '2024-09-10',
-            'disposal_scheduled_date' => '2024-09-20'  
+            'disposal_scheduled_date'   => '2024-09-20',
         ]);
         \Log::debug('$response', ['context' => $response]);
         $response->assertRedirect('items'); //URLにリダイレクト
         $response->assertStatus(302);
 
         $this->assertDatabaseHas('items', [
-            'category_id' => 1,
-            'minimum_stock' => 2
+            'category_id'   => 1,
+            'minimum_stock' => 2,
         ]);
     }
 
@@ -345,46 +323,46 @@ class StoreValidationTest extends TestCase
         // 世界を構築
         // $categories = Category::factory()->count(11)->create();
         $category = Category::factory()->create([
-            'id' => 2,
-            'name' => 'IT機器'
+            'id'   => 2,
+            'name' => 'IT機器',
         ]);
-        $units = Unit::factory()->count(10)->create();
-        $usage_statuses = UsageStatus::factory()->count(2)->create();
-        $locations = Location::factory()->count(12)->create();
+        $units              = Unit::factory()->count(10)->create();
+        $usage_statuses     = UsageStatus::factory()->count(2)->create();
+        $locations          = Location::factory()->count(12)->create();
         $aquisition_methods = AcquisitionMethod::factory()->count(6)->create();
-        
+
         $user = User::factory()->role(1)->create();
         $this->actingAs($user);
 
         $response = $this->from('items/create')->post('items', [
-            'name' => 'ペーパータオル',
-            'category_id' => $category->id,
-            'image1' => null,
-            'stock' => 10,
-            'unit_id' => $units->first()->id,
-            'minimum_stock' => 2,
-            'notification' => true,
-            'usage_status_id' => $usage_statuses->first()->id,
-            'end_user' => '山田',
-            'location_of_use_id' => $locations->first()->id,
-            'storage_location_id' => $locations->first()->id,
-            'acquisition_method_id' => $aquisition_methods->first()->id,
-            'acquisition_source' => 'Amazon',
-            'price' => 500,
-            'date_of_acquisition' => '2024-09-03',
-            'manufacturer' => null,
-            'product_number' => null,
-            'remarks' => 'テストコードです',
-            'qrcode' => null,
+            'name'                      => 'ペーパータオル',
+            'category_id'               => $category->id,
+            'image1'                    => null,
+            'stock'                     => 10,
+            'unit_id'                   => $units->first()->id,
+            'minimum_stock'             => 2,
+            'notification'              => true,
+            'usage_status_id'           => $usage_statuses->first()->id,
+            'end_user'                  => '山田',
+            'location_of_use_id'        => $locations->first()->id,
+            'storage_location_id'       => $locations->first()->id,
+            'acquisition_method_id'     => $aquisition_methods->first()->id,
+            'acquisition_source'        => 'Amazon',
+            'price'                     => 500,
+            'date_of_acquisition'       => '2024-09-03',
+            'manufacturer'              => null,
+            'product_number'            => null,
+            'remarks'                   => 'テストコードです',
+            'qrcode'                    => null,
             'inspection_scheduled_date' => '2024-09-10',
-            'disposal_scheduled_date' => '2024-09-20'  
+            'disposal_scheduled_date'   => '2024-09-20',
         ]);
         $response->assertRedirect('items'); //URLにリダイレクト
         $response->assertStatus(302);
-        
+
         $this->assertDatabaseHas('items', [
-            'category_id' => $category->id,
-            'minimum_stock' => null
+            'category_id'   => $category->id,
+            'minimum_stock' => null,
         ]);
     }
 
@@ -399,19 +377,19 @@ class StoreValidationTest extends TestCase
         $this->actingAs($user);
 
         $response = $this->from('items/create')->post('items', [
-            'category_id' => 1,
-            'minimum_stock' => -1
+            'category_id'   => 1,
+            'minimum_stock' => -1,
         ]);
         $response->assertRedirect('items/create'); //URLにリダイレクト
         $response->assertStatus(302);
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Create')
-            ->has('errors.minimum_stock')
-            ->where('errors.minimum_stock', '通知在庫数には、0以上の数字を指定してください。')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Create')
+                ->has('errors.minimum_stock')
+                ->where('errors.minimum_stock', '通知在庫数には、0以上の数字を指定してください。')
+                // ->dump()
         );
     }
 
@@ -425,18 +403,18 @@ class StoreValidationTest extends TestCase
         $this->actingAs($user);
 
         $response = $this->from('items/create')->post('items', [
-            'category_id' => 1,
-            'minimum_stock' => 0
+            'category_id'   => 1,
+            'minimum_stock' => 0,
         ]);
         $response->assertRedirect('items/create'); //URLにリダイレクト
         $response->assertStatus(302);
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Create')
-            ->missing('errors.minimum_stock')
-            ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Create')
+                ->missing('errors.minimum_stock')
+                ->dump()
         );
     }
 
@@ -447,18 +425,18 @@ class StoreValidationTest extends TestCase
         $this->actingAs($user);
 
         $response = $this->from('items/create')->post('items', [
-            'category_id' => 1,
-            'minimum_stock' => 50
+            'category_id'   => 1,
+            'minimum_stock' => 50,
         ]);
         $response->assertRedirect('items/create'); //URLにリダイレクト
         $response->assertStatus(302);
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Create')
-            ->missing('errors.minimum_stock')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Create')
+                ->missing('errors.minimum_stock')
+                // ->dump()
         );
     }
 
@@ -469,22 +447,21 @@ class StoreValidationTest extends TestCase
         $this->actingAs($user);
 
         $response = $this->from('items/create')->post('items', [
-            'category_id' => 1,
-            'minimum_stock' => 51
+            'category_id'   => 1,
+            'minimum_stock' => 51,
         ]);
         $response->assertRedirect('items/create'); //URLにリダイレクト
         $response->assertStatus(302);
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Create')
-            ->has('errors.minimum_stock')
-            ->where('errors.minimum_stock', '通知在庫数には、50以下の数字を指定してください。')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Create')
+                ->has('errors.minimum_stock')
+                ->where('errors.minimum_stock', '通知在庫数には、50以下の数字を指定してください。')
+                // ->dump()
         );
     }
-
 
     // 新規登録のunit_idのバリデーションのテスト
     /** @test */
@@ -502,11 +479,11 @@ class StoreValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Create')
-            ->has('errors.unit_id')
-            ->where('errors.unit_id', '選択された単位は正しくありません。')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Create')
+                ->has('errors.unit_id')
+                ->where('errors.unit_id', '選択された単位は正しくありません。')
+                // ->dump()
         );
     }
 
@@ -525,10 +502,10 @@ class StoreValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Create')
-            ->missing('errors.unit_id')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Create')
+                ->missing('errors.unit_id')
+                // ->dump()
         );
     }
 
@@ -547,10 +524,10 @@ class StoreValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Create')
-            ->missing('errors.unit_id')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Create')
+                ->missing('errors.unit_id')
+                // ->dump()
         );
     }
 
@@ -569,19 +546,16 @@ class StoreValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Create')
-            ->has('errors.unit_id')
-            ->where('errors.unit_id', '選択された単位は正しくありません。')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Create')
+                ->has('errors.unit_id')
+                ->where('errors.unit_id', '選択された単位は正しくありません。')
+                // ->dump()
         );
     }
 
-    
     // チェックボックスの値が保存されるかのテスト
     // →保存されるかどうかのテストは新規登録でやっているので大丈夫
-
-
 
     // 新規登録のusage_status_idのバリデーションのテスト
     /** @test */
@@ -599,11 +573,11 @@ class StoreValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Create')
-            ->has('errors.usage_status_id')
-            ->where('errors.usage_status_id', '選択された利用状況は正しくありません。')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Create')
+                ->has('errors.usage_status_id')
+                ->where('errors.usage_status_id', '選択された利用状況は正しくありません。')
+                // ->dump()
         );
     }
 
@@ -622,10 +596,10 @@ class StoreValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Create')
-            ->missing('errors.usage_status_id')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Create')
+                ->missing('errors.usage_status_id')
+                // ->dump()
         );
     }
 
@@ -644,10 +618,10 @@ class StoreValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Create')
-            ->missing('errors.usage_status_id')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Create')
+                ->missing('errors.usage_status_id')
+                // ->dump()
         );
     }
 
@@ -666,16 +640,14 @@ class StoreValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Create')
-            ->has('errors.usage_status_id')
-            ->where('errors.usage_status_id', '選択された利用状況は正しくありません。')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Create')
+                ->has('errors.usage_status_id')
+                ->where('errors.usage_status_id', '選択された利用状況は正しくありません。')
+                // ->dump()
         );
     }
 
-    
-    
     // 新規登録のend_userのバリデーションのテスト
     /** @test */
     public function 備品新規登録バリデーションend_user空欄のまま保存できる()
@@ -690,9 +662,9 @@ class StoreValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Create')
-            ->missing('errors.end_user')
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Create')
+                ->missing('errors.end_user')
         );
     }
 
@@ -709,9 +681,9 @@ class StoreValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Create')
-            ->missing('errors.end_user')
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Create')
+                ->missing('errors.end_user')
         );
     }
 
@@ -728,9 +700,9 @@ class StoreValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Create')
-            ->missing('errors.end_user')
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Create')
+                ->missing('errors.end_user')
         );
     }
 
@@ -740,7 +712,7 @@ class StoreValidationTest extends TestCase
         $user = User::factory()->role(1)->create();
         $this->actingAs($user);
 
-        $url = 'items';
+        $url      = 'items';
         $response = $this->from('items/create')->post($url, ['end_user' => str_repeat('あ', 11)]);
 
         $response->assertRedirect('items/create'); //URLにリダイレクト
@@ -748,13 +720,12 @@ class StoreValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Create')
-            ->has('errors.end_user')
-            ->where('errors.end_user', '使用者は、10文字以下で指定してください。')
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Create')
+                ->has('errors.end_user')
+                ->where('errors.end_user', '使用者は、10文字以下で指定してください。')
         );
     }
-    
 
     // 新規登録のlocation_of_use_idのバリデーションのテスト
     /** @test */
@@ -772,11 +743,11 @@ class StoreValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Create')
-            ->has('errors.location_of_use_id')
-            ->where('errors.location_of_use_id', '選択された利用場所は正しくありません。')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Create')
+                ->has('errors.location_of_use_id')
+                ->where('errors.location_of_use_id', '選択された利用場所は正しくありません。')
+                // ->dump()
         );
     }
 
@@ -795,10 +766,10 @@ class StoreValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Create')
-            ->missing('errors.location_of_use_id')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Create')
+                ->missing('errors.location_of_use_id')
+                // ->dump()
         );
     }
 
@@ -810,7 +781,7 @@ class StoreValidationTest extends TestCase
 
         $user = User::factory()->role(1)->create();
         $this->actingAs($user);
-        
+
         dump(Location::max('id'));
 
         $response = $this->from('items/create')->post('items', ['location_of_use_id' => $locations->max('id')]);
@@ -819,10 +790,10 @@ class StoreValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Create')
-            ->missing('errors.location_of_use_id')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Create')
+                ->missing('errors.location_of_use_id')
+                // ->dump()
         );
     }
 
@@ -841,14 +812,13 @@ class StoreValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Create')
-            ->has('errors.location_of_use_id')
-            ->where('errors.location_of_use_id', '選択された利用場所は正しくありません。')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Create')
+                ->has('errors.location_of_use_id')
+                ->where('errors.location_of_use_id', '選択された利用場所は正しくありません。')
+                // ->dump()
         );
     }
-
 
     // 新規登録のstorage_location_idのバリデーションのテスト
     /** @test */
@@ -866,11 +836,11 @@ class StoreValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Create')
-            ->has('errors.storage_location_id')
-            ->where('errors.storage_location_id', '選択された保管場所は正しくありません。')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Create')
+                ->has('errors.storage_location_id')
+                ->where('errors.storage_location_id', '選択された保管場所は正しくありません。')
+                // ->dump()
         );
     }
 
@@ -889,10 +859,10 @@ class StoreValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Create')
-            ->missing('errors.storage_location_id')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Create')
+                ->missing('errors.storage_location_id')
+                // ->dump()
         );
     }
 
@@ -904,20 +874,20 @@ class StoreValidationTest extends TestCase
 
         $user = User::factory()->role(1)->create();
         $this->actingAs($user);
-        
+
         dump(Location::max('id'));
 
         $response = $this->from('items/create')->post('items', ['storage_location_id' => Location::max('id')]);
-        // $response = $this->from('items/create')->post('items', ['storage_location_id' => 12]);
+                                                   // $response = $this->from('items/create')->post('items', ['storage_location_id' => 12]);
         $response->assertRedirect('items/create'); //URLにリダイレクト
         $response->assertStatus(302);
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Create')
-            ->missing('errors.storage_location_id')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Create')
+                ->missing('errors.storage_location_id')
+                // ->dump()
         );
     }
 
@@ -936,14 +906,13 @@ class StoreValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Create')
-            ->has('errors.storage_location_id')
-            ->where('errors.storage_location_id', '選択された保管場所は正しくありません。')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Create')
+                ->has('errors.storage_location_id')
+                ->where('errors.storage_location_id', '選択された保管場所は正しくありません。')
+                // ->dump()
         );
     }
-
 
     // 新規登録のacquisition_method_idのバリデーションのテスト
     /** @test */
@@ -961,11 +930,11 @@ class StoreValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Create')
-            ->has('errors.acquisition_method_id')
-            ->where('errors.acquisition_method_id', '選択された取得区分は正しくありません。')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Create')
+                ->has('errors.acquisition_method_id')
+                ->where('errors.acquisition_method_id', '選択された取得区分は正しくありません。')
+                // ->dump()
         );
     }
 
@@ -984,10 +953,10 @@ class StoreValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Create')
-            ->missing('errors.acquisition_method_id')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Create')
+                ->missing('errors.acquisition_method_id')
+                // ->dump()
         );
     }
 
@@ -999,20 +968,20 @@ class StoreValidationTest extends TestCase
 
         $user = User::factory()->role(1)->create();
         $this->actingAs($user);
-        
+
         dump(AcquisitionMethod::max('id'));
 
         $response = $this->from('items/create')->post('items', ['acquisition_method_id' => AcquisitionMethod::max('id')]);
-        // $response = $this->from('items/create')->post('items', ['acquisition_method_id' => 12]);
+                                                   // $response = $this->from('items/create')->post('items', ['acquisition_method_id' => 12]);
         $response->assertRedirect('items/create'); //URLにリダイレクト
         $response->assertStatus(302);
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Create')
-            ->missing('errors.acquisition_method_id')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Create')
+                ->missing('errors.acquisition_method_id')
+                // ->dump()
         );
     }
 
@@ -1026,20 +995,19 @@ class StoreValidationTest extends TestCase
         $this->actingAs($user);
 
         $response = $this->from('items/create')->post('items', ['acquisition_method_id' => AcquisitionMethod::max('id') + 1]);
-        // $response = $this->from('items/create')->post('items', ['acquisition_method_id' => 13]);
+                                                   // $response = $this->from('items/create')->post('items', ['acquisition_method_id' => 13]);
         $response->assertRedirect('items/create'); //URLにリダイレクト
         $response->assertStatus(302);
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Create')
-            ->has('errors.acquisition_method_id')
-            ->where('errors.acquisition_method_id', '選択された取得区分は正しくありません。')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Create')
+                ->has('errors.acquisition_method_id')
+                ->where('errors.acquisition_method_id', '選択された取得区分は正しくありません。')
+                // ->dump()
         );
     }
-
 
     // 新規登録のacquisition_sourceのバリデーションのテスト
     /** @test */
@@ -1054,10 +1022,10 @@ class StoreValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Create')
-            ->has('errors.acquisition_source')
-            ->where('errors.acquisition_source', '取得先は必ず指定してください。')
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Create')
+                ->has('errors.acquisition_source')
+                ->where('errors.acquisition_source', '取得先は必ず指定してください。')
         );
     }
 
@@ -1067,15 +1035,15 @@ class StoreValidationTest extends TestCase
         $user = User::factory()->role(1)->create();
         $this->actingAs($user);
 
-        $response = $this->from('items/create')->post('items', ['acquisition_source' => str_repeat('あ', 1)] );
+        $response = $this->from('items/create')->post('items', ['acquisition_source' => str_repeat('あ', 1)]);
         $response->assertRedirect('items/create'); //URLにリダイレクト
         $response->assertStatus(302);
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Create')
-            ->missing('errors.acquisition_source')
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Create')
+                ->missing('errors.acquisition_source')
         );
     }
 
@@ -1085,15 +1053,15 @@ class StoreValidationTest extends TestCase
         $user = User::factory()->role(1)->create();
         $this->actingAs($user);
 
-        $response = $this->from('items/create')->post('items', ['acquisition_source' => str_repeat('あ', 20)] );
+        $response = $this->from('items/create')->post('items', ['acquisition_source' => str_repeat('あ', 20)]);
         $response->assertRedirect('items/create'); //URLにリダイレクト
         $response->assertStatus(302);
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Create')
-            ->missing('errors.acquisition_source')
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Create')
+                ->missing('errors.acquisition_source')
         );
     }
 
@@ -1103,19 +1071,18 @@ class StoreValidationTest extends TestCase
         $user = User::factory()->role(1)->create();
         $this->actingAs($user);
 
-        $response = $this->from('items/create')->post('items', ['acquisition_source' => str_repeat('あ', 21)] );
+        $response = $this->from('items/create')->post('items', ['acquisition_source' => str_repeat('あ', 21)]);
         $response->assertRedirect('items/create'); //URLにリダイレクト
         $response->assertStatus(302);
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Create')
-            ->has('errors.acquisition_source')
-            ->where('errors.acquisition_source', '取得先は、20文字以下で指定してください。')
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Create')
+                ->has('errors.acquisition_source')
+                ->where('errors.acquisition_source', '取得先は、20文字以下で指定してください。')
         );
     }
-
 
     // 新規登録のpriceのバリデーションのテスト
     /** @test */
@@ -1130,10 +1097,10 @@ class StoreValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Create')
-            ->has('errors.price')
-            ->where('errors.price', '価格は必ず指定してください。')
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Create')
+                ->has('errors.price')
+                ->where('errors.price', '価格は必ず指定してください。')
         );
     }
 
@@ -1149,10 +1116,10 @@ class StoreValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Create')
-            ->has('errors.price')
-            ->where('errors.price', '価格は整数で指定してください。')
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Create')
+                ->has('errors.price')
+                ->where('errors.price', '価格は整数で指定してください。')
         );
     }
 
@@ -1162,16 +1129,16 @@ class StoreValidationTest extends TestCase
         $user = User::factory()->role(1)->create();
         $this->actingAs($user);
 
-        $response = $this->from('items/create')->post('items', ['price' => -1] );
+        $response = $this->from('items/create')->post('items', ['price' => -1]);
         $response->assertRedirect('items/create'); //URLにリダイレクト
         $response->assertStatus(302);
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Create')
-            ->has('errors.price')
-            ->where('errors.price', '価格には、0以上の数字を指定してください。')
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Create')
+                ->has('errors.price')
+                ->where('errors.price', '価格には、0以上の数字を指定してください。')
         );
     }
 
@@ -1181,15 +1148,15 @@ class StoreValidationTest extends TestCase
         $user = User::factory()->role(1)->create();
         $this->actingAs($user);
 
-        $response = $this->from('items/create')->post('items', ['price' => 0] );
+        $response = $this->from('items/create')->post('items', ['price' => 0]);
         $response->assertRedirect('items/create'); //URLにリダイレクト
         $response->assertStatus(302);
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Create')
-            ->missing('errors.price')
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Create')
+                ->missing('errors.price')
         );
     }
 
@@ -1199,15 +1166,15 @@ class StoreValidationTest extends TestCase
         $user = User::factory()->role(1)->create();
         $this->actingAs($user);
 
-        $response = $this->from('items/create')->post('items', ['price' => 1000000] );
+        $response = $this->from('items/create')->post('items', ['price' => 1000000]);
         $response->assertRedirect('items/create'); //URLにリダイレクト
         $response->assertStatus(302);
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Create')
-            ->missing('errors.price')
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Create')
+                ->missing('errors.price')
         );
     }
 
@@ -1217,20 +1184,18 @@ class StoreValidationTest extends TestCase
         $user = User::factory()->role(1)->create();
         $this->actingAs($user);
 
-        $response = $this->from('items/create')->post('items', ['price' => 1000001] );
+        $response = $this->from('items/create')->post('items', ['price' => 1000001]);
         $response->assertRedirect('items/create'); //URLにリダイレクト
         $response->assertStatus(302);
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Create')
-            ->has('errors.price')
-            ->where('errors.price', '価格には、1000000以下の数字を指定してください。')
-        );     
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Create')
+                ->has('errors.price')
+                ->where('errors.price', '価格には、1000000以下の数字を指定してください。')
+        );
     }
-
-
 
     // 新規登録のdate_of_acquisitionのバリデーションのテスト
     /** @test */
@@ -1239,16 +1204,16 @@ class StoreValidationTest extends TestCase
         $user = User::factory()->role(1)->create();
         $this->actingAs($user);
 
-        $response = $this->from('items/create')->post('items', ['date_of_acquisition' => ''] );
+        $response = $this->from('items/create')->post('items', ['date_of_acquisition' => '']);
         $response->assertRedirect('items/create'); //URLにリダイレクト
         $response->assertStatus(302);
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Create')
-            ->has('errors.date_of_acquisition')
-            ->where('errors.date_of_acquisition', '取得年月日は必ず指定してください。')
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Create')
+                ->has('errors.date_of_acquisition')
+                ->where('errors.date_of_acquisition', '取得年月日は必ず指定してください。')
         );
     }
 
@@ -1261,16 +1226,16 @@ class StoreValidationTest extends TestCase
         // 今日より未来の日付を生成
         $tomorrow = Carbon::now()->addDays(1)->format('Y-m-d');
 
-        $response = $this->from('items/create')->post('items', ['date_of_acquisition' => $tomorrow] );
+        $response = $this->from('items/create')->post('items', ['date_of_acquisition' => $tomorrow]);
         $response->assertRedirect('items/create'); //URLにリダイレクト
         $response->assertStatus(302);
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Create')
-            ->has('errors.date_of_acquisition')
-            ->where('errors.date_of_acquisition', '取得年月日には、今日以前の日付をご利用ください。')
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Create')
+                ->has('errors.date_of_acquisition')
+                ->where('errors.date_of_acquisition', '取得年月日には、今日以前の日付をご利用ください。')
         );
     }
 
@@ -1285,16 +1250,16 @@ class StoreValidationTest extends TestCase
 
         // dump($today);
 
-        $response = $this->from('items/create')->post('items', ['date_of_acquisition' => $today] );
+        $response = $this->from('items/create')->post('items', ['date_of_acquisition' => $today]);
         $response->assertRedirect('items/create'); //URLにリダイレクト
         $response->assertStatus(302);
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Create')
-            ->missing('errors.date_of_acquisition')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Create')
+                ->missing('errors.date_of_acquisition')
+                // ->dump()
         );
     }
 
@@ -1309,19 +1274,18 @@ class StoreValidationTest extends TestCase
 
         dump($yesterday);
 
-        $response = $this->from('items/create')->post('items', ['date_of_acquisition' => $yesterday] );
+        $response = $this->from('items/create')->post('items', ['date_of_acquisition' => $yesterday]);
         $response->assertRedirect('items/create'); //URLにリダイレクト
         $response->assertStatus(302);
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Create')
-            ->missing('errors.date_of_acquisition')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Create')
+                ->missing('errors.date_of_acquisition')
+                // ->dump()
         );
     }
-
 
     // 新規登録のmanufacturerのバリデーションのテスト
     /** @test */
@@ -1337,9 +1301,9 @@ class StoreValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Create')
-            ->missing('errors.manufacturer')
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Create')
+                ->missing('errors.manufacturer')
         );
     }
 
@@ -1356,9 +1320,9 @@ class StoreValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Create')
-            ->missing('errors.manufacturer')
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Create')
+                ->missing('errors.manufacturer')
         );
     }
 
@@ -1375,9 +1339,9 @@ class StoreValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Create')
-            ->missing('errors.manufacturer')
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Create')
+                ->missing('errors.manufacturer')
         );
     }
 
@@ -1394,14 +1358,12 @@ class StoreValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Create')
-            ->has('errors.manufacturer')
-            ->where('errors.manufacturer', 'メーカーは、20文字以下で指定してください。')
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Create')
+                ->has('errors.manufacturer')
+                ->where('errors.manufacturer', 'メーカーは、20文字以下で指定してください。')
         );
     }
-    
-
 
     // 新規登録のproduct_numberのバリデーションのテスト
     /** @test */
@@ -1417,9 +1379,9 @@ class StoreValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Create')
-            ->missing('errors.product_number')
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Create')
+                ->missing('errors.product_number')
         );
     }
 
@@ -1436,9 +1398,9 @@ class StoreValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Create')
-            ->missing('errors.product_number')
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Create')
+                ->missing('errors.product_number')
         );
     }
 
@@ -1455,9 +1417,9 @@ class StoreValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Create')
-            ->missing('errors.product_number')
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Create')
+                ->missing('errors.product_number')
         );
     }
 
@@ -1474,14 +1436,12 @@ class StoreValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Create')
-            ->has('errors.product_number')
-            ->where('errors.product_number', '製品番号は、30文字以下で指定してください。')
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Create')
+                ->has('errors.product_number')
+                ->where('errors.product_number', '製品番号は、30文字以下で指定してください。')
         );
     }
-
-
 
     // 新規登録のremarksのバリデーションのテスト
     /** @test */
@@ -1497,9 +1457,9 @@ class StoreValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Create')
-            ->missing('errors.remarks')
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Create')
+                ->missing('errors.remarks')
         );
     }
 
@@ -1516,9 +1476,9 @@ class StoreValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Create')
-            ->missing('errors.remarks')
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Create')
+                ->missing('errors.remarks')
         );
     }
 
@@ -1535,9 +1495,9 @@ class StoreValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Create')
-            ->missing('errors.remarks')
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Create')
+                ->missing('errors.remarks')
         );
     }
 
@@ -1554,14 +1514,12 @@ class StoreValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Create')
-            ->has('errors.remarks')
-            ->where('errors.remarks', '備考は、500文字以下で指定してください。')
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Create')
+                ->has('errors.remarks')
+                ->where('errors.remarks', '備考は、500文字以下で指定してください。')
         );
     }
-
-
 
     // 新規登録のinspection_scheduled_dateのバリデーションのテスト
     /** @test */
@@ -1570,15 +1528,15 @@ class StoreValidationTest extends TestCase
         $user = User::factory()->role(1)->create();
         $this->actingAs($user);
 
-        $response = $this->from('items/create')->post('items', ['inspection_scheduled_date' => ''] );
+        $response = $this->from('items/create')->post('items', ['inspection_scheduled_date' => '']);
         $response->assertRedirect('items/create'); //URLにリダイレクト
         $response->assertStatus(302);
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Create')
-            ->missing('errors.inspection_scheduled_date')
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Create')
+                ->missing('errors.inspection_scheduled_date')
         );
     }
 
@@ -1594,18 +1552,18 @@ class StoreValidationTest extends TestCase
         $yesterday = Carbon::now()->subDay()->format('Y-m-d');
 
         $response = $this->from('items/create')->post('items', [
-            'date_of_acquisition' => $date_of_acquisition,
-            'inspection_scheduled_date' => $yesterday
-        ] );
+            'date_of_acquisition'       => $date_of_acquisition,
+            'inspection_scheduled_date' => $yesterday,
+        ]);
         $response->assertRedirect('items/create'); //URLにリダイレクト
         $response->assertStatus(302);
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Create')
-            ->has('errors.inspection_scheduled_date')
-            ->where('errors.inspection_scheduled_date', '点検予定日は取得年月日以降の日付を入力してください')
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Create')
+                ->has('errors.inspection_scheduled_date')
+                ->where('errors.inspection_scheduled_date', '点検予定日は取得年月日以降の日付を入力してください')
         );
     }
 
@@ -1621,17 +1579,17 @@ class StoreValidationTest extends TestCase
         $today = Carbon::now()->format('Y-m-d');
 
         $response = $this->from('items/create')->post('items', [
-            'date_of_acquisition' => $date_of_acquisition,
-            'inspection_scheduled_date' => $today
-        ] );
+            'date_of_acquisition'       => $date_of_acquisition,
+            'inspection_scheduled_date' => $today,
+        ]);
         $response->assertRedirect('items/create'); //URLにリダイレクト
         $response->assertStatus(302);
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Create')
-            ->missing('errors.inspection_scheduled_date')
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Create')
+                ->missing('errors.inspection_scheduled_date')
         );
     }
 
@@ -1647,17 +1605,17 @@ class StoreValidationTest extends TestCase
         $threeYearsLater = Carbon::now()->addYears(3)->format('Y-m-d');
 
         $response = $this->from('items/create')->post('items', [
-            'date_of_acquisition' => $date_of_acquisition,
-            'inspection_scheduled_date' => $threeYearsLater 
-        ] );
+            'date_of_acquisition'       => $date_of_acquisition,
+            'inspection_scheduled_date' => $threeYearsLater,
+        ]);
         $response->assertRedirect('items/create'); //URLにリダイレクト
         $response->assertStatus(302);
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Create')
-            ->missing('errors.inspection_scheduled_date')
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Create')
+                ->missing('errors.inspection_scheduled_date')
         );
     }
 
@@ -1673,22 +1631,20 @@ class StoreValidationTest extends TestCase
         $threeYearsAndOneDayLater = Carbon::now()->addYears(3)->addDay()->format('Y-m-d');
 
         $response = $this->from('items/create')->post('items', [
-            'date_of_acquisition' => $date_of_acquisition,
-            'inspection_scheduled_date' => $threeYearsAndOneDayLater 
-        ] );
+            'date_of_acquisition'       => $date_of_acquisition,
+            'inspection_scheduled_date' => $threeYearsAndOneDayLater,
+        ]);
         $response->assertRedirect('items/create'); //URLにリダイレクト
         $response->assertStatus(302);
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Create')
-            ->has('errors.inspection_scheduled_date')
-            ->where('errors.inspection_scheduled_date', '点検予定日は取得年月日から3年以内の日付を入力してください')
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Create')
+                ->has('errors.inspection_scheduled_date')
+                ->where('errors.inspection_scheduled_date', '点検予定日は取得年月日から3年以内の日付を入力してください')
         );
     }
-
-
 
     // 新規登録のdisposal_scheduled_dateのバリデーションのテスト
     /** @test */
@@ -1697,15 +1653,15 @@ class StoreValidationTest extends TestCase
         $user = User::factory()->role(1)->create();
         $this->actingAs($user);
 
-        $response = $this->from('items/create')->post('items', ['disposal_scheduled_date' => ''] );
+        $response = $this->from('items/create')->post('items', ['disposal_scheduled_date' => '']);
         $response->assertRedirect('items/create'); //URLにリダイレクト
         $response->assertStatus(302);
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Create')
-            ->missing('errors.disposal_scheduled_date')
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Create')
+                ->missing('errors.disposal_scheduled_date')
         );
     }
 
@@ -1721,18 +1677,18 @@ class StoreValidationTest extends TestCase
         $yesterday = Carbon::now()->subDay()->format('Y-m-d');
 
         $response = $this->from('items/create')->post('items', [
-            'date_of_acquisition' => $date_of_acquisition,
-            'disposal_scheduled_date' => $yesterday
-        ] );
+            'date_of_acquisition'     => $date_of_acquisition,
+            'disposal_scheduled_date' => $yesterday,
+        ]);
         $response->assertRedirect('items/create'); //URLにリダイレクト
         $response->assertStatus(302);
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Create')
-            ->has('errors.disposal_scheduled_date')
-            ->where('errors.disposal_scheduled_date', '廃棄予定日は取得年月日以降の日付を入力してください')
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Create')
+                ->has('errors.disposal_scheduled_date')
+                ->where('errors.disposal_scheduled_date', '廃棄予定日は取得年月日以降の日付を入力してください')
         );
     }
 
@@ -1748,17 +1704,17 @@ class StoreValidationTest extends TestCase
         $today = Carbon::now()->format('Y-m-d');
 
         $response = $this->from('items/create')->post('items', [
-            'date_of_acquisition' => $date_of_acquisition,
-            'disposal_scheduled_date' => $today
-        ] );
+            'date_of_acquisition'     => $date_of_acquisition,
+            'disposal_scheduled_date' => $today,
+        ]);
         $response->assertRedirect('items/create'); //URLにリダイレクト
         $response->assertStatus(302);
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Create')
-            ->missing('errors.disposal_scheduled_date')
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Create')
+                ->missing('errors.disposal_scheduled_date')
         );
     }
 
@@ -1774,17 +1730,17 @@ class StoreValidationTest extends TestCase
         $threeYearsLater = Carbon::now()->addYears(3)->format('Y-m-d');
 
         $response = $this->from('items/create')->post('items', [
-            'date_of_acquisition' => $date_of_acquisition,
-            'disposal_scheduled_date' => $threeYearsLater 
-        ] );
+            'date_of_acquisition'     => $date_of_acquisition,
+            'disposal_scheduled_date' => $threeYearsLater,
+        ]);
         $response->assertRedirect('items/create'); //URLにリダイレクト
         $response->assertStatus(302);
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Create')
-            ->missing('errors.disposal_scheduled_date')
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Create')
+                ->missing('errors.disposal_scheduled_date')
         );
     }
 
@@ -1800,18 +1756,18 @@ class StoreValidationTest extends TestCase
         $threeYearsAndOneDayLater = Carbon::now()->addYears(3)->addDay()->format('Y-m-d');
 
         $response = $this->from('items/create')->post('items', [
-            'date_of_acquisition' => $date_of_acquisition,
-            'disposal_scheduled_date' => $threeYearsAndOneDayLater 
-        ] );
+            'date_of_acquisition'     => $date_of_acquisition,
+            'disposal_scheduled_date' => $threeYearsAndOneDayLater,
+        ]);
         $response->assertRedirect('items/create'); //URLにリダイレクト
         $response->assertStatus(302);
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Create')
-            ->has('errors.disposal_scheduled_date')
-            ->where('errors.disposal_scheduled_date', '廃棄予定日は取得年月日から3年以内の日付を入力してください')
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Create')
+                ->has('errors.disposal_scheduled_date')
+                ->where('errors.disposal_scheduled_date', '廃棄予定日は取得年月日から3年以内の日付を入力してください')
         );
     }
 }

--- a/tests/Feature/Http/Controllers/ItemController/Update/UpdateMethodTest.php
+++ b/tests/Feature/Http/Controllers/ItemController/Update/UpdateMethodTest.php
@@ -2,41 +2,25 @@
 
 namespace Tests\Feature\Http\Controllers\ItemController\Update;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
-use Tests\TestCase;
-use App\Models\User;
-use App\Models\Item;
-use App\Models\Unit;
-use App\Models\Category;
-use App\Models\Location;
-use App\Models\UsageStatus;
 use App\Models\AcquisitionMethod;
+use App\Models\Category;
 use App\Models\Disposal;
 use App\Models\Edithistory;
-use App\Models\Inspection;
 use App\Models\EditReason;
-use App\Models\RequestStatus;
-use App\Models\StockTransaction;
+use App\Models\Inspection;
+use App\Models\Item;
+use App\Models\Location;
+use App\Models\Unit;
+use App\Models\UsageStatus;
+use App\Models\User;
 use App\Services\ImageService;
 use Faker\Factory as FakerFactory;
-use Inertia\Testing\AssertableInertia as Assert;
-use Mockery;
-use App\Services\ManagementIdService;
-use Illuminate\Support\Facades\Auth;
-use Carbon\Carbon;
 use GuzzleHttp\Promise\Create;
-use Illuminate\Database\Console\DumpCommand;
-use Illuminate\Testing\Fluent\AssertableJson;
-use Inertia\Inertia;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\UploadedFile;
-use Illuminate\Support\Facades\Storage;
-use Intervention\Image\ImageManager;
-// use Intervention\Image\Drivers\Gd\Driver;
-use Intervention\Image\Drivers\Imagick\Driver;
 use Illuminate\Support\Facades\Session;
-
-
+use Mockery;
+use Tests\TestCase;
 
 class UpdateMethodTest extends TestCase
 {
@@ -45,7 +29,7 @@ class UpdateMethodTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->faker = FakerFactory::create(); 
+        $this->faker = FakerFactory::create();
     }
 
     protected function tearDown(): void
@@ -55,7 +39,7 @@ class UpdateMethodTest extends TestCase
     }
 
     /** @test */
-    function 備品編集画面で備品を編集更新できる_点検予定日のレコードが存在かつ廃棄予定日のレコードが存在_画像アップロードはモック()
+    public function 備品編集画面で備品を編集更新できる_点検予定日のレコードが存在かつ廃棄予定日のレコードが存在_画像アップロードはモック()
     {
         $this->withoutExceptionHandling(); // 詳細なエラーメッセージを表示
 
@@ -72,25 +56,25 @@ class UpdateMethodTest extends TestCase
             ->andReturn('mocked_image.jpg');
 
         // サービスコンテナにモックを登録
-        $this->app->instance(ImageService::class, $this->imageService);    
+        $this->app->instance(ImageService::class, $this->imageService);
 
         // 世界の構築
         // 変更前後のカテゴリを準備
         $category_after = Category::factory()->create([
-            'id' => 1,
-            'name' => '消耗品'
+            'id'   => 1,
+            'name' => '消耗品',
         ]);
         $category_before = Category::factory()->create([
-            'id' => 2,
-            'name' => 'IT機器'
+            'id'   => 2,
+            'name' => 'IT機器',
         ]);
-        $categories = Category::factory()->count(9)->create(); //残りのカテゴリ
-        $categories = $categories->concat($category_before)->concat($category_after); //全てのカテゴリ
-        $units = Unit::factory()->count(10)->create();
-        $usage_statuses = UsageStatus::factory()->count(2)->create();
-        $locations = Location::factory()->count(12)->create();
+        $categories         = Category::factory()->count(9)->create();                        //残りのカテゴリ
+        $categories         = $categories->concat($category_before)->concat($category_after); //全てのカテゴリ
+        $units              = Unit::factory()->count(10)->create();
+        $usage_statuses     = UsageStatus::factory()->count(2)->create();
+        $locations          = Location::factory()->count(12)->create();
         $aquisition_methods = AcquisitionMethod::factory()->count(6)->create();
-        $edit_reasons = EditReason::factory()->count(5)->create();
+        $edit_reasons       = EditReason::factory()->count(5)->create();
 
         // adminユーザーを作成
         $user = User::factory()->role(1)->create();
@@ -99,34 +83,34 @@ class UpdateMethodTest extends TestCase
         // 変更前の備品を作成
         // ここでItemObserverのcreatedでedithistoryに$operation_type=storeで保存される
         $item = Item::factory()->create([
-            'name' => '備品名変更前',
-            'category_id' => $category_before->id,
-            'image1' => null,
-            'stock' => 10,
-            'unit_id' => $units[0]->id,
-            'minimum_stock' => 2,
-            'notification' => 1, //trueだとパスしない
-            'usage_status_id' => $usage_statuses[0]->id,
-            'end_user' => '鈴木',
-            'location_of_use_id' => $locations[0]->id,
-            'storage_location_id' => $locations[0]->id,
+            'name'                  => '備品名変更前',
+            'category_id'           => $category_before->id,
+            'image1'                => null,
+            'stock'                 => 10,
+            'unit_id'               => $units[0]->id,
+            'minimum_stock'         => 2,
+            'notification'          => 1, //trueだとパスしない
+            'usage_status_id'       => $usage_statuses[0]->id,
+            'end_user'              => '鈴木',
+            'location_of_use_id'    => $locations[0]->id,
+            'storage_location_id'   => $locations[0]->id,
             'acquisition_method_id' => $aquisition_methods[0]->id,
-            'acquisition_source' => 'Amazon',
-            'price' => 500,
-            'date_of_acquisition' => '2024-09-01',
-            'manufacturer' => null,
-            'product_number' => null,
-            'remarks' => '備考更新前',
+            'acquisition_source'    => 'Amazon',
+            'price'                 => 500,
+            'date_of_acquisition'   => '2024-09-01',
+            'manufacturer'          => null,
+            'product_number'        => null,
+            'remarks'               => '備考更新前',
         ]);
-        
+
         // 点検予定日のレコードが存在する場合
         // ここでInspectionObserverのcreatedメソッドで
         // $operation_type=storeゆえにedithistory(既存のものを編集した場合なので)には保存されない
         session(['operation_type' => 'store']);
         $inspection = Inspection::factory()->create([
-            'item_id' => $item->id,
+            'item_id'                   => $item->id,
             'inspection_scheduled_date' => '2024-09-05',
-            'status' => false
+            'status'                    => false,
         ]);
         session()->forget('operation_type'); // セッションから'operation_type'を削除
 
@@ -135,60 +119,60 @@ class UpdateMethodTest extends TestCase
         // $operation_type=storeゆえにedithistory(既存のものを編集した場合なので)には保存されない
         session(['operation_type' => 'store']);
         $disposal = Disposal::factory()->create([
-            'item_id' => $item->id,
+            'item_id'                 => $item->id,
             'disposal_scheduled_date' => '2024-09-15',
         ]);
         session()->forget('operation_type'); // セッションから'operation_type'を削除
 
         $validData = [
-            'name' => '備品名更新後',
-            'category_id' => $category_after->id,
-            'image_file' => $this->fakeImage,
-            'stock' => 11,
-            'unit_id' => $units[1]->id,
-            'minimum_stock' => 3,
-            'notification' => 0,
-            'usage_status_id' => $usage_statuses[1]->id,
-            'end_user' => '山田',
-            'location_of_use_id' => $locations[1]->id,
-            'storage_location_id' => $locations[1]->id,
-            'acquisition_method_id' => $aquisition_methods[1]->id,
-            'acquisition_source' => '楽天',
-            'price' => 1000,
-            'date_of_acquisition' => '2024-09-02',
-            'manufacturer' => 'メーカー更新後',
-            'product_number' => '製品番号更新後',
-            'remarks' => '備考更新後',
+            'name'                      => '備品名更新後',
+            'category_id'               => $category_after->id,
+            'image_file'                => $this->fakeImage,
+            'stock'                     => 11,
+            'unit_id'                   => $units[1]->id,
+            'minimum_stock'             => 3,
+            'notification'              => 0,
+            'usage_status_id'           => $usage_statuses[1]->id,
+            'end_user'                  => '山田',
+            'location_of_use_id'        => $locations[1]->id,
+            'storage_location_id'       => $locations[1]->id,
+            'acquisition_method_id'     => $aquisition_methods[1]->id,
+            'acquisition_source'        => '楽天',
+            'price'                     => 1000,
+            'date_of_acquisition'       => '2024-09-02',
+            'manufacturer'              => 'メーカー更新後',
+            'product_number'            => '製品番号更新後',
+            'remarks'                   => '備考更新後',
             'inspection_scheduled_date' => '2024-09-10',
-            'disposal_scheduled_date' => '2024-09-20',
-            'edit_reason_id' => $edit_reasons->first()->id,
-            'edit_reason_text' => 'あいうえおかきくけこ',
+            'disposal_scheduled_date'   => '2024-09-20',
+            'edit_reason_id'            => $edit_reasons->first()->id,
+            'edit_reason_text'          => 'あいうえおかきくけこ',
         ];
 
-        $response = $this->from('items/'.$item->id.'/edit')
+        $response = $this->from('items/' . $item->id . '/edit')
             ->put(route('items.update', $item), $validData);
         $response->assertRedirect(route('items.show', ['item' => $item]));
         $response->assertStatus(302);
 
         $this->assertDatabaseHas('items', [
-            'name' => '備品名更新後',
-            'category_id' => $category_after->id,
-            'image1' => 'mocked_image.jpg',
-            'stock' => 11,
-            'unit_id' => $units[1]->id,
-            'minimum_stock' => 3,
-            'notification' => 0,
-            'usage_status_id' => $usage_statuses[1]->id,
-            'end_user' => '山田',
-            'location_of_use_id' => $locations[1]->id,
-            'storage_location_id' => $locations[1]->id,
+            'name'                  => '備品名更新後',
+            'category_id'           => $category_after->id,
+            'image1'                => 'mocked_image.jpg',
+            'stock'                 => 11,
+            'unit_id'               => $units[1]->id,
+            'minimum_stock'         => 3,
+            'notification'          => 0,
+            'usage_status_id'       => $usage_statuses[1]->id,
+            'end_user'              => '山田',
+            'location_of_use_id'    => $locations[1]->id,
+            'storage_location_id'   => $locations[1]->id,
             'acquisition_method_id' => $aquisition_methods[1]->id,
-            'acquisition_source' => '楽天',
-            'price' => 1000,
-            'date_of_acquisition' => '2024-09-02',
-            'manufacturer' => 'メーカー更新後',
-            'product_number' => '製品番号更新後',
-            'remarks' => '備考更新後',
+            'acquisition_source'    => '楽天',
+            'price'                 => 1000,
+            'date_of_acquisition'   => '2024-09-02',
+            'manufacturer'          => 'メーカー更新後',
+            'product_number'        => '製品番号更新後',
+            'remarks'               => '備考更新後',
         ]);
 
         // 更新されたことのチェック 同じレコードかどうか
@@ -212,27 +196,27 @@ class UpdateMethodTest extends TestCase
         $this->assertSame('メーカー更新後', $item->manufacturer);
         $this->assertSame('製品番号更新後', $item->product_number);
         $this->assertSame('備考更新後', $item->remarks);
-            
+
         // inspectionsテーブルに保存されているか確認
         $inspection->refresh();
         //2件、更新ではなく、新規にレコードが追加されている
         $this->assertDatabaseCount('inspections', 1);
         $this->assertDatabaseHas('inspections', [
-            'item_id' => $item->id,
-            'inspection_scheduled_date' =>  '2024-09-10',
-            'status' => 0,
+            'item_id'                   => $item->id,
+            'inspection_scheduled_date' => '2024-09-10',
+            'status'                    => 0,
         ]);
 
         // disposalsテーブルに保存されているか確認
         $disposal->refresh();
         $this->assertDatabaseCount('disposals', 1);
         $this->assertDatabaseHas('disposals', [
-            'item_id' => $item->id,
+            'item_id'                 => $item->id,
             'disposal_scheduled_date' => '2024-09-20',
         ]);
 
         dump(Edithistory::all()->toArray());
-        
+
         // edithistoriesには計21件のレコードが作成された
         // 最初の準備で1件のItemControllerのstore->備品作成時1レコード
         // （点検レコード更新で1レコード、廃棄レコード更新で1レコードの場合はedithistoriesには保存されない）
@@ -240,48 +224,48 @@ class UpdateMethodTest extends TestCase
         $this->assertDatabaseCount('edithistories', 21);
 
         $fields = [
-            'name' => ['old_value' => '備品名変更前', 'new_value' => '備品名更新後'],
-            'category_id' => ['old_value' => $category_before->id, 'new_value' => $category_after->id],
+            'name'                      => ['old_value' => '備品名変更前', 'new_value' => '備品名更新後'],
+            'category_id'               => ['old_value' => $category_before->id, 'new_value' => $category_after->id],
             // ItemObserver側で$fiedlsがimage1の時はedithistoryに保存しないようにした
             // 理由：アプリの編集履歴に画像名が出るのも良くないから
             // 'image1' => ['old_value' => null, 'new_value' => 'mocked_image.jpg'],
-            'stock' => ['old_value' => 10, 'new_value' => 11],
-            'unit_id' => ['old_value' => $units[0]->id, 'new_value' => $units[1]->id],
-            'minimum_stock' => ['old_value' => 2, 'new_value' => 3],
-            'notification' => ['old_value' => 1, 'new_value' => 0],
-            'usage_status_id' => ['old_value' => $usage_statuses[0]->id, 'new_value' => $usage_statuses[1]->id],
-            'end_user' => ['old_value' => '鈴木', 'new_value' => '山田'],
-            'location_of_use_id' => ['old_value' => $locations[0]->id, 'new_value' => $locations[1]->id],
-            'storage_location_id' => ['old_value' => $locations[0]->id, 'new_value' => $locations[1]->id],
-            'acquisition_method_id' => ['old_value' => $aquisition_methods[0]->id, 'new_value' => $aquisition_methods[1]->id],
-            'acquisition_source' => ['old_value' => 'Amazon', 'new_value' => '楽天'],
-            'price' => ['old_value' => 500, 'new_value' => 1000],
-            'date_of_acquisition' => ['old_value' => '2024-09-01', 'new_value' => '2024-09-02'],
-            'manufacturer' => ['old_value' => null, 'new_value' => 'メーカー更新後'],
-            'product_number' => ['old_value' => null, 'new_value' => '製品番号更新後'],
-            'remarks' => ['old_value' => '備考更新前', 'new_value' => '備考更新後'],
+            'stock'                     => ['old_value' => 10, 'new_value' => 11],
+            'unit_id'                   => ['old_value' => $units[0]->id, 'new_value' => $units[1]->id],
+            'minimum_stock'             => ['old_value' => 2, 'new_value' => 3],
+            'notification'              => ['old_value' => 1, 'new_value' => 0],
+            'usage_status_id'           => ['old_value' => $usage_statuses[0]->id, 'new_value' => $usage_statuses[1]->id],
+            'end_user'                  => ['old_value' => '鈴木', 'new_value' => '山田'],
+            'location_of_use_id'        => ['old_value' => $locations[0]->id, 'new_value' => $locations[1]->id],
+            'storage_location_id'       => ['old_value' => $locations[0]->id, 'new_value' => $locations[1]->id],
+            'acquisition_method_id'     => ['old_value' => $aquisition_methods[0]->id, 'new_value' => $aquisition_methods[1]->id],
+            'acquisition_source'        => ['old_value' => 'Amazon', 'new_value' => '楽天'],
+            'price'                     => ['old_value' => 500, 'new_value' => 1000],
+            'date_of_acquisition'       => ['old_value' => '2024-09-01', 'new_value' => '2024-09-02'],
+            'manufacturer'              => ['old_value' => null, 'new_value' => 'メーカー更新後'],
+            'product_number'            => ['old_value' => null, 'new_value' => '製品番号更新後'],
+            'remarks'                   => ['old_value' => '備考更新前', 'new_value' => '備考更新後'],
             'inspection_scheduled_date' => ['old_value' => '2024-09-05', 'new_value' => '2024-09-10'],
-            'disposal_scheduled_date' => ['old_value' => '2024-09-15', 'new_value' => '2024-09-20']
+            'disposal_scheduled_date'   => ['old_value' => '2024-09-15', 'new_value' => '2024-09-20'],
         ];
-        
+
         foreach ($fields as $field => $values) {
             $this->assertDatabaseHas('edithistories', [
-                'edit_mode' => 'normal',
-                'operation_type' => 'update',
-                'item_id' => $item->id,
-                'edited_field' => $field,
-                'old_value' => $values['old_value'],
-                'new_value' => $values['new_value'],
-                'edit_user' => $user->name ?? '',
-                'edit_reason_id' => $edit_reasons->first()->id,
+                'edit_mode'        => 'normal',
+                'operation_type'   => 'update',
+                'item_id'          => $item->id,
+                'edited_field'     => $field,
+                'old_value'        => $values['old_value'],
+                'new_value'        => $values['new_value'],
+                'edit_user'        => $user->name ?? '',
+                'edit_reason_id'   => $edit_reasons->first()->id,
                 'edit_reason_text' => 'あいうえおかきくけこ',
             ]);
         }
     }
 
     /** @test */
-    function 備品編集画面で備品を編集更新できる_点検予定日のレコードが無いかつ廃棄予定日のレコードが無い_画像アップロードはモック()
-    {   
+    public function 備品編集画面で備品を編集更新できる_点検予定日のレコードが無いかつ廃棄予定日のレコードが無い_画像アップロードはモック()
+    {
         // フェイクの画像ファイルを作成
         $this->fakeImage = UploadedFile::fake()->image('test_image.jpg');
 
@@ -295,24 +279,24 @@ class UpdateMethodTest extends TestCase
             ->andReturn('mocked_image.jpg');
 
         // サービスコンテナにモックを登録
-        $this->app->instance(ImageService::class, $this->imageService);    
+        $this->app->instance(ImageService::class, $this->imageService);
 
         // 世界の構築
         $category_after = Category::factory()->create([
-            'id' => 1,
-            'name' => '消耗品'
+            'id'   => 1,
+            'name' => '消耗品',
         ]);
         $category_before = Category::factory()->create([
-            'id' => 2,
-            'name' => 'IT機器'
+            'id'   => 2,
+            'name' => 'IT機器',
         ]);
-        $categories = Category::factory()->count(9)->create(); //残りのカテゴリ
-        $categories = $categories->concat($category_before)->concat($category_after); //全てのカテゴリ
-        $units = Unit::factory()->count(10)->create();
-        $usage_statuses = UsageStatus::factory()->count(2)->create();
-        $locations = Location::factory()->count(12)->create();
+        $categories         = Category::factory()->count(9)->create();                        //残りのカテゴリ
+        $categories         = $categories->concat($category_before)->concat($category_after); //全てのカテゴリ
+        $units              = Unit::factory()->count(10)->create();
+        $usage_statuses     = UsageStatus::factory()->count(2)->create();
+        $locations          = Location::factory()->count(12)->create();
         $aquisition_methods = AcquisitionMethod::factory()->count(6)->create();
-        $edit_reasons = EditReason::factory()->count(5)->create();
+        $edit_reasons       = EditReason::factory()->count(5)->create();
 
         // adminユーザーを作成
         $user = User::factory()->role(1)->create();
@@ -321,75 +305,75 @@ class UpdateMethodTest extends TestCase
         // 変更前の備品を作成
         // ここでItemObserverのcreatedでedithistoryに$operation_type=storeで保存される
         $item = Item::factory()->create([
-            'name' => '備品名変更前',
-            'category_id' => $category_before->id,
-            'image1' => null,
-            'stock' => 10,
-            'unit_id' => $units[0]->id,
-            'minimum_stock' => 2,
-            'notification' => 1, //trueだとパスしない
-            'usage_status_id' => $usage_statuses[0]->id,
-            'end_user' => '鈴木',
-            'location_of_use_id' => $locations[0]->id,
-            'storage_location_id' => $locations[0]->id,
+            'name'                  => '備品名変更前',
+            'category_id'           => $category_before->id,
+            'image1'                => null,
+            'stock'                 => 10,
+            'unit_id'               => $units[0]->id,
+            'minimum_stock'         => 2,
+            'notification'          => 1, //trueだとパスしない
+            'usage_status_id'       => $usage_statuses[0]->id,
+            'end_user'              => '鈴木',
+            'location_of_use_id'    => $locations[0]->id,
+            'storage_location_id'   => $locations[0]->id,
             'acquisition_method_id' => $aquisition_methods[0]->id,
-            'acquisition_source' => 'Amazon',
-            'price' => 500,
-            'date_of_acquisition' => '2024-09-01',
-            'manufacturer' => null,
-            'product_number' => null,
-            'remarks' => '備考更新前',
+            'acquisition_source'    => 'Amazon',
+            'price'                 => 500,
+            'date_of_acquisition'   => '2024-09-01',
+            'manufacturer'          => null,
+            'product_number'        => null,
+            'remarks'               => '備考更新前',
         ]);
 
         $validData = [
-            'name' => '備品名更新後',
-            'category_id' => $category_after->id,
-            'image_file' => $this->fakeImage,
-            'stock' => 11,
-            'unit_id' => $units[1]->id,
-            'minimum_stock' => 3,
-            'notification' => 0,
-            'usage_status_id' => $usage_statuses[1]->id,
-            'end_user' => '山田',
-            'location_of_use_id' => $locations[1]->id,
-            'storage_location_id' => $locations[1]->id,
-            'acquisition_method_id' => $aquisition_methods[1]->id,
-            'acquisition_source' => '楽天',
-            'price' => 1000,
-            'date_of_acquisition' => '2024-09-02',
-            'manufacturer' => 'メーカー更新後',
-            'product_number' => '製品番号更新後',
-            'remarks' => '備考更新後',
+            'name'                      => '備品名更新後',
+            'category_id'               => $category_after->id,
+            'image_file'                => $this->fakeImage,
+            'stock'                     => 11,
+            'unit_id'                   => $units[1]->id,
+            'minimum_stock'             => 3,
+            'notification'              => 0,
+            'usage_status_id'           => $usage_statuses[1]->id,
+            'end_user'                  => '山田',
+            'location_of_use_id'        => $locations[1]->id,
+            'storage_location_id'       => $locations[1]->id,
+            'acquisition_method_id'     => $aquisition_methods[1]->id,
+            'acquisition_source'        => '楽天',
+            'price'                     => 1000,
+            'date_of_acquisition'       => '2024-09-02',
+            'manufacturer'              => 'メーカー更新後',
+            'product_number'            => '製品番号更新後',
+            'remarks'                   => '備考更新後',
             'inspection_scheduled_date' => '2024-09-10',
-            'disposal_scheduled_date' => '2024-09-20',
-            'edit_reason_id' => $edit_reasons->first()->id,
-            'edit_reason_text' => 'あいうえおかきくけこ',
+            'disposal_scheduled_date'   => '2024-09-20',
+            'edit_reason_id'            => $edit_reasons->first()->id,
+            'edit_reason_text'          => 'あいうえおかきくけこ',
         ];
 
-        $response = $this->from('items/'.$item->id.'/edit')
+        $response = $this->from('items/' . $item->id . '/edit')
             ->put(route('items.update', $item), $validData);
         $response->assertRedirect(route('items.show', ['item' => $item]));
         $response->assertStatus(302);
 
         $this->assertDatabaseHas('items', [
-            'name' => '備品名更新後',
-            'category_id' => $category_after->id,
-            'image1' => 'mocked_image.jpg',
-            'stock' => 11,
-            'unit_id' => $units[1]->id,
-            'minimum_stock' => 3,
-            'notification' => 0,
-            'usage_status_id' => $usage_statuses[1]->id,
-            'end_user' => '山田',
-            'location_of_use_id' => $locations[1]->id,
-            'storage_location_id' => $locations[1]->id,
+            'name'                  => '備品名更新後',
+            'category_id'           => $category_after->id,
+            'image1'                => 'mocked_image.jpg',
+            'stock'                 => 11,
+            'unit_id'               => $units[1]->id,
+            'minimum_stock'         => 3,
+            'notification'          => 0,
+            'usage_status_id'       => $usage_statuses[1]->id,
+            'end_user'              => '山田',
+            'location_of_use_id'    => $locations[1]->id,
+            'storage_location_id'   => $locations[1]->id,
             'acquisition_method_id' => $aquisition_methods[1]->id,
-            'acquisition_source' => '楽天',
-            'price' => 1000,
-            'date_of_acquisition' => '2024-09-02',
-            'manufacturer' => 'メーカー更新後',
-            'product_number' => '製品番号更新後',
-            'remarks' => '備考更新後',
+            'acquisition_source'    => '楽天',
+            'price'                 => 1000,
+            'date_of_acquisition'   => '2024-09-02',
+            'manufacturer'          => 'メーカー更新後',
+            'product_number'        => '製品番号更新後',
+            'remarks'               => '備考更新後',
         ]);
 
         // 更新されたことのチェック 同じレコードかどうか
@@ -413,20 +397,19 @@ class UpdateMethodTest extends TestCase
         $this->assertSame('メーカー更新後', $item->manufacturer);
         $this->assertSame('製品番号更新後', $item->product_number);
         $this->assertSame('備考更新後', $item->remarks);
-        
-        
+
         // inspectionsテーブルに保存されているか確認
         $this->assertDatabaseCount('inspections', 1);
         $this->assertDatabaseHas('inspections', [
-            'item_id' => $item->id,
-            'inspection_scheduled_date' =>  '2024-09-10',
-            'status' => 0,
+            'item_id'                   => $item->id,
+            'inspection_scheduled_date' => '2024-09-10',
+            'status'                    => 0,
         ]);
 
         // disposalsテーブルに保存されているか確認
         $this->assertDatabaseCount('disposals', 1);
         $this->assertDatabaseHas('disposals', [
-            'item_id' => $item->id,
+            'item_id'                 => $item->id,
             'disposal_scheduled_date' => '2024-09-20',
         ]);
 
@@ -437,40 +420,40 @@ class UpdateMethodTest extends TestCase
         $this->assertDatabaseCount('edithistories', 21);
 
         $fields = [
-            'name' => ['old_value' => '備品名変更前', 'new_value' => '備品名更新後'],
-            'category_id' => ['old_value' => $category_before->id, 'new_value' => $category_after->id],
+            'name'                      => ['old_value' => '備品名変更前', 'new_value' => '備品名更新後'],
+            'category_id'               => ['old_value' => $category_before->id, 'new_value' => $category_after->id],
             // ItemObserver側で$fiedlsがimage1の時はedithistoryに保存しないようにした
             // 理由：アプリの編集履歴に画像名が出るのも良くないから
-            // 'image1' => ['old_value' => null, 'new_value' => 'mocked_image.jpg'], 
-            'stock' => ['old_value' => 10, 'new_value' => 11],
-            'unit_id' => ['old_value' => $units[0]->id, 'new_value' => $units[1]->id],
-            'minimum_stock' => ['old_value' => 2, 'new_value' => 3],
-            'notification' => ['old_value' => 1, 'new_value' => 0],
-            'usage_status_id' => ['old_value' => $usage_statuses[0]->id, 'new_value' => $usage_statuses[1]->id],
-            'end_user' => ['old_value' => '鈴木', 'new_value' => '山田'],
-            'location_of_use_id' => ['old_value' => $locations[0]->id, 'new_value' => $locations[1]->id],
-            'storage_location_id' => ['old_value' => $locations[0]->id, 'new_value' => $locations[1]->id],
-            'acquisition_method_id' => ['old_value' => $aquisition_methods[0]->id, 'new_value' => $aquisition_methods[1]->id],
-            'acquisition_source' => ['old_value' => 'Amazon', 'new_value' => '楽天'],
-            'price' => ['old_value' => 500, 'new_value' => 1000],
-            'date_of_acquisition' => ['old_value' => '2024-09-01', 'new_value' => '2024-09-02'],
-            'manufacturer' => ['old_value' => null, 'new_value' => 'メーカー更新後'],
-            'product_number' => ['old_value' => null, 'new_value' => '製品番号更新後'],
-            'remarks' => ['old_value' => '備考更新前', 'new_value' => '備考更新後'],
+            // 'image1' => ['old_value' => null, 'new_value' => 'mocked_image.jpg'],
+            'stock'                     => ['old_value' => 10, 'new_value' => 11],
+            'unit_id'                   => ['old_value' => $units[0]->id, 'new_value' => $units[1]->id],
+            'minimum_stock'             => ['old_value' => 2, 'new_value' => 3],
+            'notification'              => ['old_value' => 1, 'new_value' => 0],
+            'usage_status_id'           => ['old_value' => $usage_statuses[0]->id, 'new_value' => $usage_statuses[1]->id],
+            'end_user'                  => ['old_value' => '鈴木', 'new_value' => '山田'],
+            'location_of_use_id'        => ['old_value' => $locations[0]->id, 'new_value' => $locations[1]->id],
+            'storage_location_id'       => ['old_value' => $locations[0]->id, 'new_value' => $locations[1]->id],
+            'acquisition_method_id'     => ['old_value' => $aquisition_methods[0]->id, 'new_value' => $aquisition_methods[1]->id],
+            'acquisition_source'        => ['old_value' => 'Amazon', 'new_value' => '楽天'],
+            'price'                     => ['old_value' => 500, 'new_value' => 1000],
+            'date_of_acquisition'       => ['old_value' => '2024-09-01', 'new_value' => '2024-09-02'],
+            'manufacturer'              => ['old_value' => null, 'new_value' => 'メーカー更新後'],
+            'product_number'            => ['old_value' => null, 'new_value' => '製品番号更新後'],
+            'remarks'                   => ['old_value' => '備考更新前', 'new_value' => '備考更新後'],
             'inspection_scheduled_date' => ['old_value' => null, 'new_value' => '2024-09-10'],
-            'disposal_scheduled_date' => ['old_value' => null, 'new_value' => '2024-09-20']
+            'disposal_scheduled_date'   => ['old_value' => null, 'new_value' => '2024-09-20'],
         ];
-        
+
         foreach ($fields as $field => $values) {
             $this->assertDatabaseHas('edithistories', [
-                'edit_mode' => 'normal',
-                'operation_type' => 'update',
-                'item_id' => $item->id,
-                'edited_field' => $field,
-                'old_value' => $values['old_value'],
-                'new_value' => $values['new_value'],
-                'edit_user' => $user->name ?? '',
-                'edit_reason_id' => $edit_reasons->first()->id,
+                'edit_mode'        => 'normal',
+                'operation_type'   => 'update',
+                'item_id'          => $item->id,
+                'edited_field'     => $field,
+                'old_value'        => $values['old_value'],
+                'new_value'        => $values['new_value'],
+                'edit_user'        => $user->name ?? '',
+                'edit_reason_id'   => $edit_reasons->first()->id,
                 'edit_reason_text' => 'あいうえおかきくけこ',
             ]);
         }

--- a/tests/Feature/Http/Controllers/ItemController/Update/UpdateValidationTest.php
+++ b/tests/Feature/Http/Controllers/ItemController/Update/UpdateValidationTest.php
@@ -2,39 +2,20 @@
 
 namespace Tests\Feature\Http\Controllers\ItemController\Update;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
-use Tests\TestCase;
-use App\Models\User;
-use App\Models\Item;
-use App\Models\Unit;
-use App\Models\Category;
-use App\Models\Location;
-use App\Models\UsageStatus;
 use App\Models\AcquisitionMethod;
-use App\Models\Edithistory;
-use App\Models\Inspection;
+use App\Models\Category;
 use App\Models\EditReason;
-use App\Models\RequestStatus;
-use App\Models\StockTransaction;
-use App\Services\ImageService;
-use Faker\Factory as FakerFactory;
-use Inertia\Testing\AssertableInertia as Assert;
-use Mockery;
-use App\Services\ManagementIdService;
-use Illuminate\Support\Facades\Auth;
+use App\Models\Item;
+use App\Models\Location;
+use App\Models\Unit;
+use App\Models\UsageStatus;
+use App\Models\User;
 use Carbon\Carbon;
-use Illuminate\Database\Console\DumpCommand;
-use Illuminate\Testing\Fluent\AssertableJson;
-use Inertia\Inertia;
-use Illuminate\Http\UploadedFile;
-use Illuminate\Support\Facades\Storage;
-use Intervention\Image\ImageManager;
-// use Intervention\Image\Drivers\Gd\Driver;
-use Intervention\Image\Drivers\Imagick\Driver;
-use Illuminate\Support\Facades\Session;
-use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Faker\Factory as FakerFactory;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
+use Inertia\Testing\AssertableInertia as Assert;
+use Tests\TestCase;
 
 class UpdateValidationTest extends TestCase
 {
@@ -58,7 +39,6 @@ class UpdateValidationTest extends TestCase
 
     protected function tearDown(): void
     {
-        // 子クラスでのクリーンアップ処理
         parent::tearDown();
     }
 
@@ -71,18 +51,18 @@ class UpdateValidationTest extends TestCase
 
         $item = Item::factory()->create();
 
-        $response = $this->from('items/'.$item->id.'/edit')
+        $response = $this->from('items/' . $item->id . '/edit')
             ->put(route('items.update', $item), ['name' => '']);
-        $response->assertRedirect('items/'.$item->id.'/edit'); //URLにリダイレクト
+        $response->assertRedirect('items/' . $item->id . '/edit'); //URLにリダイレクト
         $response->assertStatus(302);
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Edit')
-            ->has('errors.name')
-            ->where('errors.name', '名前は必ず指定してください。')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Edit')
+                ->has('errors.name')
+                ->where('errors.name', '名前は必ず指定してください。')
+                // ->dump()
         );
     }
 
@@ -94,17 +74,17 @@ class UpdateValidationTest extends TestCase
 
         $item = Item::factory()->create();
 
-        $response = $this->from('items/'.$item->id.'/edit')
+        $response = $this->from('items/' . $item->id . '/edit')
             ->put(route('items.update', $item), ['name' => str_repeat('あ', 1)]);
-        $response->assertRedirect('items/'.$item->id.'/edit'); //URLにリダイレクト
+        $response->assertRedirect('items/' . $item->id . '/edit'); //URLにリダイレクト
         $response->assertStatus(302);
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Edit')
-            ->missing('errors.name')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Edit')
+                ->missing('errors.name')
+                // ->dump()
         );
     }
 
@@ -116,17 +96,17 @@ class UpdateValidationTest extends TestCase
 
         $item = Item::factory()->create();
 
-        $response = $this->from('items/'.$item->id.'/edit')
+        $response = $this->from('items/' . $item->id . '/edit')
             ->put(route('items.update', $item), ['name' => str_repeat('あ', 40)]);
-        $response->assertRedirect('items/'.$item->id.'/edit'); //URLにリダイレクト
+        $response->assertRedirect('items/' . $item->id . '/edit'); //URLにリダイレクト
         $response->assertStatus(302);
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Edit')
-            ->missing('errors.name')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Edit')
+                ->missing('errors.name')
+                // ->dump()
         );
     }
 
@@ -138,23 +118,22 @@ class UpdateValidationTest extends TestCase
 
         $item = Item::factory()->create();
 
-        $response = $this->from('items/'.$item->id.'/edit')
+        $response = $this->from('items/' . $item->id . '/edit')
             ->put(route('items.update', $item), ['name' => str_repeat('あ', 41)]);
-        $response->assertRedirect('items/'.$item->id.'/edit'); //URLにリダイレクト
+        $response->assertRedirect('items/' . $item->id . '/edit'); //URLにリダイレクト
         $response->assertStatus(302);
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Edit')
-            ->has('errors.name')
-            ->where('errors.name', '名前は、40文字以下で指定してください。')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Edit')
+                ->has('errors.name')
+                ->where('errors.name', '名前は、40文字以下で指定してください。')
+                // ->dump()
         );
     }
 
-
-    // 編集更新のcategory_idのバリデーションのテスト    
+    // 編集更新のcategory_idのバリデーションのテスト
     /** @test */
     public function 備品編集更新バリデーションcategoryIdが最小値より小さい無効値()
     {
@@ -166,18 +145,18 @@ class UpdateValidationTest extends TestCase
 
         $item = Item::factory()->create();
 
-        $response = $this->from('items/'.$item->id.'/edit')
-            ->put(route('items.update', $item),  ['category_id' => $categories->min('id') - 1]);
-        $response->assertRedirect('items/'.$item->id.'/edit'); //URLにリダイレクト
+        $response = $this->from('items/' . $item->id . '/edit')
+            ->put(route('items.update', $item), ['category_id' => $categories->min('id') - 1]);
+        $response->assertRedirect('items/' . $item->id . '/edit'); //URLにリダイレクト
         $response->assertStatus(302);
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Edit')
-            ->has('errors.category_id')
-            ->where('errors.category_id', '選択されたカテゴリは正しくありません。')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Edit')
+                ->has('errors.category_id')
+                ->where('errors.category_id', '選択されたカテゴリは正しくありません。')
+                // ->dump()
         );
     }
 
@@ -192,17 +171,17 @@ class UpdateValidationTest extends TestCase
 
         $item = Item::factory()->create();
 
-        $response = $this->from('items/'.$item->id.'/edit')
-            ->put(route('items.update', $item),  ['category_id' => $categories->min('id')]);
-        $response->assertRedirect('items/'.$item->id.'/edit'); //URLにリダイレクト
+        $response = $this->from('items/' . $item->id . '/edit')
+            ->put(route('items.update', $item), ['category_id' => $categories->min('id')]);
+        $response->assertRedirect('items/' . $item->id . '/edit'); //URLにリダイレクト
         $response->assertStatus(302);
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Edit')
-            ->missing('errors.category_id')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Edit')
+                ->missing('errors.category_id')
+                // ->dump()
         );
     }
 
@@ -217,17 +196,17 @@ class UpdateValidationTest extends TestCase
 
         $item = Item::factory()->create();
 
-        $response = $this->from('items/'.$item->id.'/edit')
-            ->put(route('items.update', $item),  ['category_id' => $categories->max('id')]);
-        $response->assertRedirect('items/'.$item->id.'/edit'); //URLにリダイレクト
+        $response = $this->from('items/' . $item->id . '/edit')
+            ->put(route('items.update', $item), ['category_id' => $categories->max('id')]);
+        $response->assertRedirect('items/' . $item->id . '/edit'); //URLにリダイレクト
         $response->assertStatus(302);
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Edit')
-            ->missing('errors.category_id')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Edit')
+                ->missing('errors.category_id')
+                // ->dump()
         );
     }
 
@@ -247,18 +226,18 @@ class UpdateValidationTest extends TestCase
         // dd($item);
         // dd($categories->max('id'));
 
-        $response = $this->from('items/'.$item->id.'/edit')
-            ->put(route('items.update', $item),  ['category_id' => $categories->max('id') + 1]);
-        $response->assertRedirect('items/'.$item->id.'/edit'); //URLにリダイレクト
+        $response = $this->from('items/' . $item->id . '/edit')
+            ->put(route('items.update', $item), ['category_id' => $categories->max('id') + 1]);
+        $response->assertRedirect('items/' . $item->id . '/edit'); //URLにリダイレクト
         $response->assertStatus(302);
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Edit')
-            ->has('errors.category_id')
-            ->where('errors.category_id', '選択されたカテゴリは正しくありません。')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Edit')
+                ->has('errors.category_id')
+                ->where('errors.category_id', '選択されたカテゴリは正しくありません。')
+                // ->dump()
         );
     }
 
@@ -270,18 +249,18 @@ class UpdateValidationTest extends TestCase
 
         $item = Item::factory()->create();
 
-        $response = $this->from('items/'.$item->id.'/edit')
+        $response = $this->from('items/' . $item->id . '/edit')
             ->put(route('items.update', $item), ['stock' => -1]);
-        $response->assertRedirect('items/'.$item->id.'/edit'); //URLにリダイレクト
+        $response->assertRedirect('items/' . $item->id . '/edit'); //URLにリダイレクト
         $response->assertStatus(302);
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Edit')
-            ->has('errors.stock')
-            ->where('errors.stock', '在庫数には、0以上の数字を指定してください。')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Edit')
+                ->has('errors.stock')
+                ->where('errors.stock', '在庫数には、0以上の数字を指定してください。')
+                // ->dump()
         );
     }
 
@@ -293,17 +272,17 @@ class UpdateValidationTest extends TestCase
 
         $item = Item::factory()->create();
 
-        $response = $this->from('items/'.$item->id.'/edit')
+        $response = $this->from('items/' . $item->id . '/edit')
             ->put(route('items.update', $item), ['stock' => 0]);
-        $response->assertRedirect('items/'.$item->id.'/edit'); //URLにリダイレクト
+        $response->assertRedirect('items/' . $item->id . '/edit'); //URLにリダイレクト
         $response->assertStatus(302);
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Edit')
-            ->missing('errors.stock')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Edit')
+                ->missing('errors.stock')
+                // ->dump()
         );
     }
 
@@ -315,17 +294,17 @@ class UpdateValidationTest extends TestCase
 
         $item = Item::factory()->create();
 
-        $response = $this->from('items/'.$item->id.'/edit')
+        $response = $this->from('items/' . $item->id . '/edit')
             ->put(route('items.update', $item), ['stock' => 200]);
-        $response->assertRedirect('items/'.$item->id.'/edit'); //URLにリダイレクト
+        $response->assertRedirect('items/' . $item->id . '/edit'); //URLにリダイレクト
         $response->assertStatus(302);
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Edit')
-            ->missing('errors.stock')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Edit')
+                ->missing('errors.stock')
+                // ->dump()
         );
     }
 
@@ -337,23 +316,22 @@ class UpdateValidationTest extends TestCase
 
         $item = Item::factory()->create();
 
-        $response = $this->from('items/'.$item->id.'/edit')
+        $response = $this->from('items/' . $item->id . '/edit')
             ->put(route('items.update', $item), ['stock' => 201]);
-        $response->assertRedirect('items/'.$item->id.'/edit'); //URLにリダイレクト
+        $response->assertRedirect('items/' . $item->id . '/edit'); //URLにリダイレクト
         $response->assertStatus(302);
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Edit')
-            ->has('errors.stock')
-            ->where('errors.stock', '在庫数には、200以下の数字を指定してください。')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Edit')
+                ->has('errors.stock')
+                ->where('errors.stock', '在庫数には、200以下の数字を指定してください。')
+                // ->dump()
         );
     }
 
-
-     // カテゴリが消耗品とそれ以外の時のminimum_stockの保存をテスト
+    // カテゴリが消耗品とそれ以外の時のminimum_stockの保存をテスト
     /** @test */
     public function 備品編集更新バリデーションカテゴリが消耗品の時はminimum_stockの値は保存される()
     {
@@ -365,60 +343,60 @@ class UpdateValidationTest extends TestCase
         // 世界を構築
         // $categories = Category::factory()->count(11)->create();
         $category = Category::factory()->create([
-            'id' => 1,
-            'name' => '消耗品'
+            'id'   => 1,
+            'name' => '消耗品',
         ]);
-        $categories = Category::factory()->count(10)->create(); //残りのカテゴリ
-        $categories = $categories->concat($category); //全てのカテゴリ
-        $units = Unit::factory()->count(10)->create();
-        $usage_statuses = UsageStatus::factory()->count(2)->create();
-        $locations = Location::factory()->count(12)->create();
+        $categories         = Category::factory()->count(10)->create(); //残りのカテゴリ
+        $categories         = $categories->concat($category);           //全てのカテゴリ
+        $units              = Unit::factory()->count(10)->create();
+        $usage_statuses     = UsageStatus::factory()->count(2)->create();
+        $locations          = Location::factory()->count(12)->create();
         $aquisition_methods = AcquisitionMethod::factory()->count(6)->create();
-        $edit_reasons = EditReason::factory()->count(5)->create();
+        $edit_reasons       = EditReason::factory()->count(5)->create();
 
         $user = User::factory()->role(1)->create();
         $this->actingAs($user);
 
         $item = Item::factory()->create([
-            'minimum_stock' => null
+            'minimum_stock' => null,
         ]);
 
         // 適切に保存されるデータでカテゴリが消耗品(catgery_id=1)の時
         // 更新リクエストを送信
-        $response = $this->from('items/'.$item->id.'/edit')
+        $response = $this->from('items/' . $item->id . '/edit')
             ->put(route('items.update', $item), [
-            'name' => 'ペーパータオル',
-            'category_id' => $category->id,
-            'image1' => null,
-            'stock' => 10,
-            'unit_id' => $units->first()->id,
-            'minimum_stock' => 2,
-            'notification' => true,
-            'usage_status_id' => $usage_statuses->first()->id,
-            'end_user' => '山田',
-            'location_of_use_id' => $locations->first()->id,
-            'storage_location_id' => $locations->first()->id,
-            'acquisition_method_id' => $aquisition_methods->first()->id,
-            'acquisition_source' => 'Amazon',
-            'price' => 500,
-            'date_of_acquisition' => '2024-09-03',
-            'manufacturer' => null,
-            'product_number' => null,
-            'remarks' => 'テストコードです',
-            'qrcode' => null,
-            'inspection_scheduled_date' => '2024-09-10',
-            'disposal_scheduled_date' => '2024-09-20',
-            'edit_reason_id' => $edit_reasons->first()->id,
-            'edit_reason_text' => '詳細理由です',
-        ]);
+                'name'                      => 'ペーパータオル',
+                'category_id'               => $category->id,
+                'image1'                    => null,
+                'stock'                     => 10,
+                'unit_id'                   => $units->first()->id,
+                'minimum_stock'             => 2,
+                'notification'              => true,
+                'usage_status_id'           => $usage_statuses->first()->id,
+                'end_user'                  => '山田',
+                'location_of_use_id'        => $locations->first()->id,
+                'storage_location_id'       => $locations->first()->id,
+                'acquisition_method_id'     => $aquisition_methods->first()->id,
+                'acquisition_source'        => 'Amazon',
+                'price'                     => 500,
+                'date_of_acquisition'       => '2024-09-03',
+                'manufacturer'              => null,
+                'product_number'            => null,
+                'remarks'                   => 'テストコードです',
+                'qrcode'                    => null,
+                'inspection_scheduled_date' => '2024-09-10',
+                'disposal_scheduled_date'   => '2024-09-20',
+                'edit_reason_id'            => $edit_reasons->first()->id,
+                'edit_reason_text'          => '詳細理由です',
+            ]);
 
-        // Show画面にリダイレクトする
+                                                                               // Show画面にリダイレクトする
         $response->assertRedirect(route('items.show', ['item' => $item->id])); //URLにリダイレクト
         $response->assertStatus(302);
 
         $this->assertDatabaseHas('items', [
-            'category_id' => 1,
-            'minimum_stock' => 2
+            'category_id'   => 1,
+            'minimum_stock' => 2,
         ]);
     }
 
@@ -433,71 +411,70 @@ class UpdateValidationTest extends TestCase
         // 世界を構築
         // $categories = Category::factory()->count(11)->create();
         $category1 = Category::factory()->create([
-            'id' => 1,
-            'name' => '消耗品'
+            'id'   => 1,
+            'name' => '消耗品',
         ]);
-        
+
         $category2 = Category::factory()->create([
-            'id' => 2,
-            'name' => 'IT機器'
+            'id'   => 2,
+            'name' => 'IT機器',
         ]);
-        $categories = Category::factory()->count(9)->create(); //残りのカテゴリ
+        $categories = Category::factory()->count(9)->create();       //残りのカテゴリ
         $categories = $categories->concat([$category1, $category2]); //全てのカテゴリ
 
-        $units = Unit::factory()->count(10)->create();
-        $usage_statuses = UsageStatus::factory()->count(2)->create();
-        $locations = Location::factory()->count(12)->create();
+        $units              = Unit::factory()->count(10)->create();
+        $usage_statuses     = UsageStatus::factory()->count(2)->create();
+        $locations          = Location::factory()->count(12)->create();
         $aquisition_methods = AcquisitionMethod::factory()->count(6)->create();
-        $edit_reasons = EditReason::factory()->count(5)->create();
+        $edit_reasons       = EditReason::factory()->count(5)->create();
 
         $user = User::factory()->role(1)->create();
         $this->actingAs($user);
 
         $item = Item::factory()->create([
-            'category_id' => $category1->id,
-            'minimum_stock' => 5
+            'category_id'   => $category1->id,
+            'minimum_stock' => 5,
         ]);
         // dd($item);
 
         // 適切に保存されるデータでカテゴリが消耗品(catgery_id=1)の時
         // 更新リクエストを送信
-        $response = $this->from('items/'.$item->id.'/edit')
+        $response = $this->from('items/' . $item->id . '/edit')
             ->put(route('items.update', $item), [
-            'name' => 'ペーパータオル',
-            'category_id' => $category2->id,
-            'image1' => null,
-            'stock' => 10,
-            'unit_id' => $units->first()->id,
-            'minimum_stock' => 2,
-            'notification' => true,
-            'usage_status_id' => $usage_statuses->first()->id,
-            'end_user' => '山田',
-            'location_of_use_id' => $locations->first()->id,
-            'storage_location_id' => $locations->first()->id,
-            'acquisition_method_id' => $aquisition_methods->first()->id,
-            'acquisition_source' => 'Amazon',
-            'price' => 500,
-            'date_of_acquisition' => '2024-09-03',
-            'manufacturer' => null,
-            'product_number' => null,
-            'remarks' => 'テストコードです',
-            'qrcode' => null,
-            'inspection_scheduled_date' => '2024-09-10',
-            'disposal_scheduled_date' => '2024-09-20',
-            'edit_reason_id' => $edit_reasons->first()->id,
-            'edit_reason_text' => '詳細理由です',
-        ]);
+                'name'                      => 'ペーパータオル',
+                'category_id'               => $category2->id,
+                'image1'                    => null,
+                'stock'                     => 10,
+                'unit_id'                   => $units->first()->id,
+                'minimum_stock'             => 2,
+                'notification'              => true,
+                'usage_status_id'           => $usage_statuses->first()->id,
+                'end_user'                  => '山田',
+                'location_of_use_id'        => $locations->first()->id,
+                'storage_location_id'       => $locations->first()->id,
+                'acquisition_method_id'     => $aquisition_methods->first()->id,
+                'acquisition_source'        => 'Amazon',
+                'price'                     => 500,
+                'date_of_acquisition'       => '2024-09-03',
+                'manufacturer'              => null,
+                'product_number'            => null,
+                'remarks'                   => 'テストコードです',
+                'qrcode'                    => null,
+                'inspection_scheduled_date' => '2024-09-10',
+                'disposal_scheduled_date'   => '2024-09-20',
+                'edit_reason_id'            => $edit_reasons->first()->id,
+                'edit_reason_text'          => '詳細理由です',
+            ]);
 
-        // Show画面にリダイレクトする
+                                                                               // Show画面にリダイレクトする
         $response->assertRedirect(route('items.show', ['item' => $item->id])); //URLにリダイレクト
         $response->assertStatus(302);
 
         $this->assertDatabaseHas('items', [
-            'category_id' => $category2->id,
-            'minimum_stock' => null
+            'category_id'   => $category2->id,
+            'minimum_stock' => null,
         ]);
     }
-
 
     /** @test */
     public function 備品編集更新バリデーションminimum_stockが最小値より小さい無効値()
@@ -508,36 +485,36 @@ class UpdateValidationTest extends TestCase
         DB::statement('SET FOREIGN_KEY_CHECKS=1;');
 
         $category = Category::factory()->create([
-            'id' => 1,
-            'name' => '消耗品'
+            'id'   => 1,
+            'name' => '消耗品',
         ]);
         $categories = Category::factory()->count(10)->create(); //残りのカテゴリ
-        $categories = $categories->concat($category); //全てのカテゴリ
+        $categories = $categories->concat($category);           //全てのカテゴリ
 
         $user = User::factory()->role(1)->create();
         $this->actingAs($user);
 
         $item = Item::factory()->create([
-            'category_id' => $category->id,
-            'minimum_stock' => 5
+            'category_id'   => $category->id,
+            'minimum_stock' => 5,
         ]);
 
-        $response = $this->from('items/'.$item->id.'/edit')
+        $response = $this->from('items/' . $item->id . '/edit')
             ->put(route('items.update', $item), [
-            'category_id' => $category->id,
-            'minimum_stock' => -1,
-        ]);
+                'category_id'   => $category->id,
+                'minimum_stock' => -1,
+            ]);
 
         $response->assertRedirect(route('items.edit', ['item' => $item->id])); //URLにリダイレクト
         $response->assertStatus(302);
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Edit')
-            ->has('errors.minimum_stock')
-            ->where('errors.minimum_stock', '通知在庫数には、0以上の数字を指定してください。')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Edit')
+                ->has('errors.minimum_stock')
+                ->where('errors.minimum_stock', '通知在庫数には、0以上の数字を指定してください。')
+                // ->dump()
         );
     }
 
@@ -550,35 +527,35 @@ class UpdateValidationTest extends TestCase
         DB::statement('SET FOREIGN_KEY_CHECKS=1;');
 
         $category = Category::factory()->create([
-            'id' => 1,
-            'name' => '消耗品'
+            'id'   => 1,
+            'name' => '消耗品',
         ]);
         $categories = Category::factory()->count(10)->create(); //残りのカテゴリ
-        $categories = $categories->concat($category); //全てのカテゴリ
+        $categories = $categories->concat($category);           //全てのカテゴリ
 
         $user = User::factory()->role(1)->create();
         $this->actingAs($user);
 
         $item = Item::factory()->create([
-            'category_id' => $category->id,
-            'minimum_stock' => 5
+            'category_id'   => $category->id,
+            'minimum_stock' => 5,
         ]);
 
-        $response = $this->from('items/'.$item->id.'/edit')
+        $response = $this->from('items/' . $item->id . '/edit')
             ->put(route('items.update', $item), [
-            'category_id' => $category->id,
-            'minimum_stock' => 0,
-        ]);
+                'category_id'   => $category->id,
+                'minimum_stock' => 0,
+            ]);
 
         $response->assertRedirect(route('items.edit', ['item' => $item->id])); //URLにリダイレクト
         $response->assertStatus(302);
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Edit')
-            ->missing('errors.minimum_stock')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Edit')
+                ->missing('errors.minimum_stock')
+                // ->dump()
         );
     }
 
@@ -591,83 +568,83 @@ class UpdateValidationTest extends TestCase
         DB::statement('SET FOREIGN_KEY_CHECKS=1;');
 
         $category = Category::factory()->create([
-            'id' => 1,
-            'name' => '消耗品'
+            'id'   => 1,
+            'name' => '消耗品',
         ]);
         $categories = Category::factory()->count(10)->create(); //残りのカテゴリ
-        $categories = $categories->concat($category); //全てのカテゴリ
+        $categories = $categories->concat($category);           //全てのカテゴリ
 
         $user = User::factory()->role(1)->create();
         $this->actingAs($user);
 
         $item = Item::factory()->create([
-            'category_id' => $category->id,
-            'minimum_stock' => 5
+            'category_id'   => $category->id,
+            'minimum_stock' => 5,
         ]);
 
-        $response = $this->from('items/'.$item->id.'/edit')
+        $response = $this->from('items/' . $item->id . '/edit')
             ->put(route('items.update', $item), [
-            'category_id' => $category->id,
-            'minimum_stock' => 50,
-        ]);
+                'category_id'   => $category->id,
+                'minimum_stock' => 50,
+            ]);
 
         $response->assertRedirect(route('items.edit', ['item' => $item->id])); //URLにリダイレクト
         $response->assertStatus(302);
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Edit')
-            ->missing('errors.minimum_stock')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Edit')
+                ->missing('errors.minimum_stock')
+                // ->dump()
         );
     }
 
     /** @test */
     public function 備品編集更新バリデーションminimum_stockが最大値を超える無効値()
-{
+    {
         // categoriesテーブルをトランケートして連番をリセット
         DB::statement('SET FOREIGN_KEY_CHECKS=0;');
         DB::table('categories')->truncate();
         DB::statement('SET FOREIGN_KEY_CHECKS=1;');
 
         $category = Category::factory()->create([
-            'id' => 1,
-            'name' => '消耗品'
+            'id'   => 1,
+            'name' => '消耗品',
         ]);
         $categories = Category::factory()->count(10)->create(); //残りのカテゴリ
-        $categories = $categories->concat($category); //全てのカテゴリ
+        $categories = $categories->concat($category);           //全てのカテゴリ
 
         $user = User::factory()->role(1)->create();
         $this->actingAs($user);
 
         $item = Item::factory()->create([
-            'category_id' => $category->id,
-            'minimum_stock' => 5
+            'category_id'   => $category->id,
+            'minimum_stock' => 5,
         ]);
 
-        $response = $this->from('items/'.$item->id.'/edit')
+        $response = $this->from('items/' . $item->id . '/edit')
             ->put(route('items.update', $item), [
-            'category_id' => $category->id,
-            'minimum_stock' => 51,
-        ]);
+                'category_id'   => $category->id,
+                'minimum_stock' => 51,
+            ]);
 
         $response->assertRedirect(route('items.edit', ['item' => $item->id])); //URLにリダイレクト
         $response->assertStatus(302);
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Edit')
-            ->has('errors.minimum_stock')
-            ->where('errors.minimum_stock', '通知在庫数には、50以下の数字を指定してください。')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Edit')
+                ->has('errors.minimum_stock')
+                ->where('errors.minimum_stock', '通知在庫数には、50以下の数字を指定してください。')
+                // ->dump()
         );
     }
 
     /** @test */
     public function 備品編集更新バリデーションunit_idが最小値より小さい無効値()
-    {   
+    {
         // categoriesテーブルをトランケートして連番をリセット
         DB::statement('SET FOREIGN_KEY_CHECKS=0;');
         DB::table('units')->truncate();
@@ -681,7 +658,7 @@ class UpdateValidationTest extends TestCase
 
         $item = Item::factory()->create();
 
-        $response = $this->from('items/'.$item->id.'/edit')
+        $response = $this->from('items/' . $item->id . '/edit')
             ->put(route('items.update', $item), ['unit_id' => $units->min('id') - 1]);
 
         $response->assertRedirect(route('items.edit', ['item' => $item->id])); //URLにリダイレクト
@@ -689,17 +666,17 @@ class UpdateValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Edit')
-            ->has('errors.unit_id')
-            ->where('errors.unit_id', '選択された単位は正しくありません。')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Edit')
+                ->has('errors.unit_id')
+                ->where('errors.unit_id', '選択された単位は正しくありません。')
+                // ->dump()
         );
     }
 
     /** @test */
     public function 備品編集更新バリデーションunit_idが最小の有効値()
-    {   
+    {
         // 世界を構築
         $units = Unit::factory()->count(10)->create();
 
@@ -708,7 +685,7 @@ class UpdateValidationTest extends TestCase
 
         $item = Item::factory()->create();
 
-        $response = $this->from('items/'.$item->id.'/edit')
+        $response = $this->from('items/' . $item->id . '/edit')
             ->put(route('items.update', $item), ['unit_id' => $units->min('id')]);
 
         $response->assertRedirect(route('items.edit', ['item' => $item->id])); //URLにリダイレクト
@@ -716,16 +693,16 @@ class UpdateValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Edit')
-            ->missing('errors.unit_id')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Edit')
+                ->missing('errors.unit_id')
+                // ->dump()
         );
     }
 
     /** @test */
     public function 備品編集更新バリデーションunit_idが最大の有効値()
-    {   
+    {
         // 世界を構築
         $units = Unit::factory()->count(10)->create();
 
@@ -734,7 +711,7 @@ class UpdateValidationTest extends TestCase
 
         $item = Item::factory()->create();
 
-        $response = $this->from('items/'.$item->id.'/edit')
+        $response = $this->from('items/' . $item->id . '/edit')
             ->put(route('items.update', $item), ['unit_id' => $units->max('id')]);
 
         $response->assertRedirect(route('items.edit', ['item' => $item->id])); //URLにリダイレクト
@@ -742,32 +719,32 @@ class UpdateValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Edit')
-            ->missing('errors.unit_id')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Edit')
+                ->missing('errors.unit_id')
+                // ->dump()
         );
     }
 
     /** @test */
     public function 備品編集更新バリデーションunit_idが最大値を超える無効値()
-    {   
-         // 外部キー制約を無効にする
+    {
+        // 外部キー制約を無効にする
         // \DB::statement('SET FOREIGN_KEY_CHECKS=0;');
 
         // 世界を構築
         $units = Unit::factory()->count(10)->create();
-        
+
         $user = User::factory()->role(1)->create();
         $this->actingAs($user);
 
         // $itemはunit_idを指定しないと、自動的に$units->max('id') + 1にインクリメントしてしまう
         // $units->first()->id、明確にDBに存在するidを指定しないと、クラス単位のテストでエラーになる
         $item = Item::factory()->create([
-            'unit_id' => $units->first()->id
+            'unit_id' => $units->first()->id,
         ]);
 
-        $response = $this->from('items/'.$item->id.'/edit')
+        $response = $this->from('items/' . $item->id . '/edit')
             ->put(route('items.update', $item), ['unit_id' => $units->max('id') + 1]);
 
         $response->assertRedirect(route('items.edit', ['item' => $item->id])); //URLにリダイレクト
@@ -775,21 +752,21 @@ class UpdateValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Edit')
-            ->has('errors.unit_id')
-            ->where('errors.unit_id', '選択された単位は正しくありません。')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Edit')
+                ->has('errors.unit_id')
+                ->where('errors.unit_id', '選択された単位は正しくありません。')
+                // ->dump()
         );
 
         // 外部キー制約を有効に戻す
         // \DB::statement('SET FOREIGN_KEY_CHECKS=1;');
     }
 
-    // usage_status_idのバリデーションのテスト    
+    // usage_status_idのバリデーションのテスト
     /** @test */
     public function 備品編集更新バリデーションusage_status_idが最小値より小さい無効値()
-    {   
+    {
         // 世界を構築
         $usage_statuses = UsageStatus::factory()->count(2)->create();
 
@@ -798,7 +775,7 @@ class UpdateValidationTest extends TestCase
 
         $item = Item::factory()->create();
 
-        $response = $this->from('items/'.$item->id.'/edit')
+        $response = $this->from('items/' . $item->id . '/edit')
             ->put(route('items.update', $item), ['usage_status_id' => $usage_statuses->min('id') - 1]);
 
         $response->assertRedirect(route('items.edit', ['item' => $item->id])); //URLにリダイレクト
@@ -806,17 +783,17 @@ class UpdateValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Edit')
-            ->has('errors.usage_status_id')
-            ->where('errors.usage_status_id', '選択された利用状況は正しくありません。')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Edit')
+                ->has('errors.usage_status_id')
+                ->where('errors.usage_status_id', '選択された利用状況は正しくありません。')
+                // ->dump()
         );
     }
 
     /** @test */
     public function 備品編集更新バリデーションusage_status_idが最小の有効値()
-    {   
+    {
         // 世界を構築
         $usage_statuses = UsageStatus::factory()->count(2)->create();
 
@@ -825,7 +802,7 @@ class UpdateValidationTest extends TestCase
 
         $item = Item::factory()->create();
 
-        $response = $this->from('items/'.$item->id.'/edit')
+        $response = $this->from('items/' . $item->id . '/edit')
             ->put(route('items.update', $item), ['usage_status_id' => $usage_statuses->min('id')]);
 
         $response->assertRedirect(route('items.edit', ['item' => $item->id])); //URLにリダイレクト
@@ -833,16 +810,16 @@ class UpdateValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Edit')
-            ->missing('errors.usage_status_id')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Edit')
+                ->missing('errors.usage_status_id')
+                // ->dump()
         );
     }
 
     /** @test */
     public function 備品編集更新バリデーションusage_status_idが最大の有効値()
-    {   
+    {
         // 世界を構築
         $usage_statuses = UsageStatus::factory()->count(2)->create();
 
@@ -851,7 +828,7 @@ class UpdateValidationTest extends TestCase
 
         $item = Item::factory()->create();
 
-        $response = $this->from('items/'.$item->id.'/edit')
+        $response = $this->from('items/' . $item->id . '/edit')
             ->put(route('items.update', $item), ['usage_status_id' => $usage_statuses->max('id')]);
 
         $response->assertRedirect(route('items.edit', ['item' => $item->id])); //URLにリダイレクト
@@ -859,16 +836,16 @@ class UpdateValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Edit')
-            ->missing('errors.usage_status_id')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Edit')
+                ->missing('errors.usage_status_id')
+                // ->dump()
         );
     }
 
     /** @test */
     public function 備品編集更新バリデーションusage_status_idが最大値を超える無効値()
-    {   
+    {
         // 世界を構築
         $usage_statuses = UsageStatus::factory()->count(2)->create();
 
@@ -878,10 +855,10 @@ class UpdateValidationTest extends TestCase
         // usage_status_idが$usage_statuses->max('id') + 1に自動でインクリメントされてしまうので指定する
         // $usage_statuses->first()->id、明確にDBに存在するidを指定しないと、クラス単位のテストでエラーになる
         $item = Item::factory()->create([
-            'usage_status_id' => $usage_statuses->first()->id
+            'usage_status_id' => $usage_statuses->first()->id,
         ]);
 
-        $response = $this->from('items/'.$item->id.'/edit')
+        $response = $this->from('items/' . $item->id . '/edit')
             ->put(route('items.update', $item), ['usage_status_id' => $usage_statuses->max('id') + 1]);
 
         $response->assertRedirect(route('items.edit', ['item' => $item->id])); //URLにリダイレクト
@@ -889,24 +866,24 @@ class UpdateValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Edit')
-            ->has('errors.usage_status_id')
-            ->where('errors.usage_status_id', '選択された利用状況は正しくありません。')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Edit')
+                ->has('errors.usage_status_id')
+                ->where('errors.usage_status_id', '選択された利用状況は正しくありません。')
+                // ->dump()
         );
     }
 
     // end_userのバリデーションのテスト
     /** @test */
     public function 備品編集更新バリデーションend_user空欄のまま保存できる()
-    {   
+    {
         $user = User::factory()->role(1)->create();
         $this->actingAs($user);
 
         $item = Item::factory()->create();
 
-        $response = $this->from('items/'.$item->id.'/edit')
+        $response = $this->from('items/' . $item->id . '/edit')
             ->put(route('items.update', $item), ['end_user' => '']);
 
         $response->assertRedirect(route('items.edit', ['item' => $item->id])); //URLにリダイレクト
@@ -914,22 +891,22 @@ class UpdateValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Edit')
-            ->missing('errors.end_user')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Edit')
+                ->missing('errors.end_user')
+                // ->dump()
         );
     }
 
     /** @test */
     public function 備品編集更新バリデーションend_user10文字で保存できる()
-    {   
+    {
         $user = User::factory()->role(1)->create();
         $this->actingAs($user);
 
         $item = Item::factory()->create();
 
-        $response = $this->from('items/'.$item->id.'/edit')
+        $response = $this->from('items/' . $item->id . '/edit')
             ->put(route('items.update', $item), ['end_user' => str_repeat('あ', 10)]);
 
         $response->assertRedirect(route('items.edit', ['item' => $item->id])); //URLにリダイレクト
@@ -937,22 +914,22 @@ class UpdateValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Edit')
-            ->missing('errors.end_user')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Edit')
+                ->missing('errors.end_user')
+                // ->dump()
         );
     }
 
     /** @test */
     public function 備品編集更新バリデーションend_user11文字で保存できない()
-    {   
+    {
         $user = User::factory()->role(1)->create();
         $this->actingAs($user);
 
         $item = Item::factory()->create();
 
-        $response = $this->from('items/'.$item->id.'/edit')
+        $response = $this->from('items/' . $item->id . '/edit')
             ->put(route('items.update', $item), ['end_user' => str_repeat('あ', 11)]);
 
         $response->assertRedirect(route('items.edit', ['item' => $item->id])); //URLにリダイレクト
@@ -960,19 +937,18 @@ class UpdateValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Edit')
-            ->has('errors.end_user')
-            ->where('errors.end_user', '使用者は、10文字以下で指定してください。')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Edit')
+                ->has('errors.end_user')
+                ->where('errors.end_user', '使用者は、10文字以下で指定してください。')
+                // ->dump()
         );
     }
-
 
     // location_of_use_idのバリデーションのテスト
     /** @test */
     public function 備品編集更新バリデーションlocation_of_use_idが最小値より小さい無効値()
-    {   
+    {
         // 世界を構築
         $locations = Location::factory()->count(12)->create();
 
@@ -981,7 +957,7 @@ class UpdateValidationTest extends TestCase
 
         $item = Item::factory()->create();
 
-        $response = $this->from('items/'.$item->id.'/edit')
+        $response = $this->from('items/' . $item->id . '/edit')
             ->put(route('items.update', $item), ['location_of_use_id' => 0]);
 
         $response->assertRedirect(route('items.edit', ['item' => $item->id])); //URLにリダイレクト
@@ -989,17 +965,17 @@ class UpdateValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Edit')
-            ->has('errors.location_of_use_id')
-            ->where('errors.location_of_use_id', '選択された利用場所は正しくありません。')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Edit')
+                ->has('errors.location_of_use_id')
+                ->where('errors.location_of_use_id', '選択された利用場所は正しくありません。')
+                // ->dump()
         );
     }
 
     /** @test */
     public function 備品編集更新バリデーションlocation_of_use_idが最小の有効値()
-    {   
+    {
         // 世界を構築
         $locations = Location::factory()->count(12)->create();
 
@@ -1008,7 +984,7 @@ class UpdateValidationTest extends TestCase
 
         $item = Item::factory()->create();
 
-        $response = $this->from('items/'.$item->id.'/edit')
+        $response = $this->from('items/' . $item->id . '/edit')
             ->put(route('items.update', $item), ['location_of_use_id' => Location::min('id')]);
 
         $response->assertRedirect(route('items.edit', ['item' => $item->id])); //URLにリダイレクト
@@ -1016,16 +992,16 @@ class UpdateValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Edit')
-            ->missing('errors.location_of_use_id')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Edit')
+                ->missing('errors.location_of_use_id')
+                // ->dump()
         );
     }
 
     /** @test */
     public function 備品編集更新バリデーションlocation_of_use_idが最大の有効値()
-    {   
+    {
         // 世界を構築
         $locations = Location::factory()->count(12)->create();
 
@@ -1034,7 +1010,7 @@ class UpdateValidationTest extends TestCase
 
         $item = Item::factory()->create();
 
-        $response = $this->from('items/'.$item->id.'/edit')
+        $response = $this->from('items/' . $item->id . '/edit')
             ->put(route('items.update', $item), ['location_of_use_id' => Location::max('id')]);
 
         $response->assertRedirect(route('items.edit', ['item' => $item->id])); //URLにリダイレクト
@@ -1042,16 +1018,16 @@ class UpdateValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Edit')
-            ->missing('errors.location_of_use_id')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Edit')
+                ->missing('errors.location_of_use_id')
+                // ->dump()
         );
     }
 
     /** @test */
     public function 備品編集更新バリデーションlocation_of_use_idが最大値を超える無効値()
-    {   
+    {
         // 世界を構築
         $locations = Location::factory()->count(12)->create();
 
@@ -1060,7 +1036,7 @@ class UpdateValidationTest extends TestCase
 
         $item = Item::factory()->create();
 
-        $response = $this->from('items/'.$item->id.'/edit')
+        $response = $this->from('items/' . $item->id . '/edit')
             ->put(route('items.update', $item), ['location_of_use_id' => Location::max('id') + 1]);
 
         $response->assertRedirect(route('items.edit', ['item' => $item->id])); //URLにリダイレクト
@@ -1068,19 +1044,18 @@ class UpdateValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Edit')
-            ->has('errors.location_of_use_id')
-            ->where('errors.location_of_use_id', '選択された利用場所は正しくありません。')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Edit')
+                ->has('errors.location_of_use_id')
+                ->where('errors.location_of_use_id', '選択された利用場所は正しくありません。')
+                // ->dump()
         );
     }
-
 
     // storage_location_idのバリデーションのテスト
     /** @test */
     public function 備品編集更新バリデーションstorage_location_idが最小値より小さい無効値()
-    {   
+    {
         // 世界を構築
         $locations = Location::factory()->count(12)->create();
 
@@ -1089,7 +1064,7 @@ class UpdateValidationTest extends TestCase
 
         $item = Item::factory()->create();
 
-        $response = $this->from('items/'.$item->id.'/edit')
+        $response = $this->from('items/' . $item->id . '/edit')
             ->put(route('items.update', $item), ['storage_location_id' => 0]);
 
         $response->assertRedirect(route('items.edit', ['item' => $item->id])); //URLにリダイレクト
@@ -1097,17 +1072,17 @@ class UpdateValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Edit')
-            ->has('errors.storage_location_id')
-            ->where('errors.storage_location_id', '選択された保管場所は正しくありません。')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Edit')
+                ->has('errors.storage_location_id')
+                ->where('errors.storage_location_id', '選択された保管場所は正しくありません。')
+                // ->dump()
         );
     }
 
     /** @test */
     public function 備品編集更新バリデーションstorage_location_idが最小の有効値()
-    {   
+    {
         // 世界を構築
         $locations = Location::factory()->count(12)->create();
 
@@ -1116,7 +1091,7 @@ class UpdateValidationTest extends TestCase
 
         $item = Item::factory()->create();
 
-        $response = $this->from('items/'.$item->id.'/edit')
+        $response = $this->from('items/' . $item->id . '/edit')
             ->put(route('items.update', $item), ['storage_location_id' => Location::min('id')]);
 
         $response->assertRedirect(route('items.edit', ['item' => $item->id])); //URLにリダイレクト
@@ -1124,16 +1099,16 @@ class UpdateValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Edit')
-            ->missing('errors.storage_location_id')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Edit')
+                ->missing('errors.storage_location_id')
+                // ->dump()
         );
     }
 
     /** @test */
     public function 備品編集更新バリデーションstorage_location_idが最大の有効値()
-    {   
+    {
         // 世界を構築
         $locations = Location::factory()->count(12)->create();
 
@@ -1142,7 +1117,7 @@ class UpdateValidationTest extends TestCase
 
         $item = Item::factory()->create();
 
-        $response = $this->from('items/'.$item->id.'/edit')
+        $response = $this->from('items/' . $item->id . '/edit')
             ->put(route('items.update', $item), ['storage_location_id' => Location::max('id')]);
 
         $response->assertRedirect(route('items.edit', ['item' => $item->id])); //URLにリダイレクト
@@ -1153,16 +1128,16 @@ class UpdateValidationTest extends TestCase
         // レスポンス内容を確認
         // dump($response->getContent());
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Edit')
-            ->missing('errors.storage_location_id')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Edit')
+                ->missing('errors.storage_location_id')
+                // ->dump()
         );
     }
 
     /** @test */
     public function 備品編集更新バリデーションstorage_location_idが最大値を超える無効値()
-    {   
+    {
         // 世界を構築
         $locations = Location::factory()->count(12)->create();
 
@@ -1171,7 +1146,7 @@ class UpdateValidationTest extends TestCase
 
         $item = Item::factory()->create();
 
-        $response = $this->from('items/'.$item->id.'/edit')
+        $response = $this->from('items/' . $item->id . '/edit')
             ->put(route('items.update', $item), ['storage_location_id' => Location::max('id') + 1]);
 
         $response->assertRedirect(route('items.edit', ['item' => $item->id])); //URLにリダイレクト
@@ -1179,19 +1154,18 @@ class UpdateValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Edit')
-            ->has('errors.storage_location_id')
-            ->where('errors.storage_location_id', '選択された保管場所は正しくありません。')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Edit')
+                ->has('errors.storage_location_id')
+                ->where('errors.storage_location_id', '選択された保管場所は正しくありません。')
+                // ->dump()
         );
     }
-
 
     // acquisition_method_idのバリデーションのテスト
     /** @test */
     public function 備品編集更新バリデーションacquisition_method_idが最小値より小さい無効値()
-    {   
+    {
         // 世界を構築
         $aquisition_methods = AcquisitionMethod::factory()->count(6)->create();
 
@@ -1200,7 +1174,7 @@ class UpdateValidationTest extends TestCase
 
         $item = Item::factory()->create();
 
-        $response = $this->from('items/'.$item->id.'/edit')
+        $response = $this->from('items/' . $item->id . '/edit')
             ->put(route('items.update', $item), ['acquisition_method_id' => 0]);
 
         $response->assertRedirect(route('items.edit', ['item' => $item->id])); //URLにリダイレクト
@@ -1208,17 +1182,17 @@ class UpdateValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Edit')
-            ->has('errors.acquisition_method_id')
-            ->where('errors.acquisition_method_id', '選択された取得区分は正しくありません。')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Edit')
+                ->has('errors.acquisition_method_id')
+                ->where('errors.acquisition_method_id', '選択された取得区分は正しくありません。')
+                // ->dump()
         );
     }
 
     /** @test */
     public function 備品編集更新バリデーションacquisition_method_idが最小の有効値()
-    {   
+    {
         // 世界を構築
         $aquisition_methods = AcquisitionMethod::factory()->count(6)->create();
 
@@ -1227,7 +1201,7 @@ class UpdateValidationTest extends TestCase
 
         $item = Item::factory()->create();
 
-        $response = $this->from('items/'.$item->id.'/edit')
+        $response = $this->from('items/' . $item->id . '/edit')
             ->put(route('items.update', $item), ['acquisition_method_id' => AcquisitionMethod::min('id')]);
 
         $response->assertRedirect(route('items.edit', ['item' => $item->id])); //URLにリダイレクト
@@ -1235,16 +1209,16 @@ class UpdateValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Edit')
-            ->missing('errors.acquisition_method_id')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Edit')
+                ->missing('errors.acquisition_method_id')
+                // ->dump()
         );
     }
 
     /** @test */
     public function 備品編集更新バリデーションacquisition_method_idが最大の有効値()
-    {   
+    {
         // 世界を構築
         $aquisition_methods = AcquisitionMethod::factory()->count(6)->create();
 
@@ -1253,7 +1227,7 @@ class UpdateValidationTest extends TestCase
 
         $item = Item::factory()->create();
 
-        $response = $this->from('items/'.$item->id.'/edit')
+        $response = $this->from('items/' . $item->id . '/edit')
             ->put(route('items.update', $item), ['acquisition_method_id' => AcquisitionMethod::max('id')]);
 
         $response->assertRedirect(route('items.edit', ['item' => $item->id])); //URLにリダイレクト
@@ -1261,16 +1235,16 @@ class UpdateValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Edit')
-            ->missing('errors.acquisition_method_id')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Edit')
+                ->missing('errors.acquisition_method_id')
+                // ->dump()
         );
     }
 
     /** @test */
     public function 備品編集更新バリデーションacquisition_method_idが最大値を超える無効値()
-    {   
+    {
         // 世界を構築
         $aquisition_methods = AcquisitionMethod::factory()->count(6)->create();
 
@@ -1279,7 +1253,7 @@ class UpdateValidationTest extends TestCase
 
         $item = Item::factory()->create();
 
-        $response = $this->from('items/'.$item->id.'/edit')
+        $response = $this->from('items/' . $item->id . '/edit')
             ->put(route('items.update', $item), ['acquisition_method_id' => AcquisitionMethod::max('id') + 1]);
 
         $response->assertRedirect(route('items.edit', ['item' => $item->id])); //URLにリダイレクト
@@ -1287,25 +1261,24 @@ class UpdateValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Edit')
-            ->has('errors.acquisition_method_id')
-            ->where('errors.acquisition_method_id', '選択された取得区分は正しくありません。')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Edit')
+                ->has('errors.acquisition_method_id')
+                ->where('errors.acquisition_method_id', '選択された取得区分は正しくありません。')
+                // ->dump()
         );
     }
-
 
     // acquisition_sourceのバリデーションのテスト
     /** @test */
     public function 備品編集更新バリデーションacquisition_sourceが空欄の無効値()
-    {   
+    {
         $user = User::factory()->role(1)->create();
         $this->actingAs($user);
 
         $item = Item::factory()->create();
 
-        $response = $this->from('items/'.$item->id.'/edit')
+        $response = $this->from('items/' . $item->id . '/edit')
             ->put(route('items.update', $item), ['acquisition_source' => '']);
 
         $response->assertRedirect(route('items.edit', ['item' => $item->id])); //URLにリダイレクト
@@ -1313,23 +1286,23 @@ class UpdateValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Edit')
-            ->has('errors.acquisition_source')
-            ->where('errors.acquisition_source', '取得先は、1文字以上で指定してください。')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Edit')
+                ->has('errors.acquisition_source')
+                ->where('errors.acquisition_source', '取得先は、1文字以上で指定してください。')
+                // ->dump()
         );
     }
 
     /** @test */
     public function 備品編集更新バリデーションacquisition_sourceが1文字の有効値()
-    {   
+    {
         $user = User::factory()->role(1)->create();
         $this->actingAs($user);
 
         $item = Item::factory()->create();
 
-        $response = $this->from('items/'.$item->id.'/edit')
+        $response = $this->from('items/' . $item->id . '/edit')
             ->put(route('items.update', $item), ['acquisition_source' => str_repeat('あ', 1)]);
 
         $response->assertRedirect(route('items.edit', ['item' => $item->id])); //URLにリダイレクト
@@ -1337,22 +1310,22 @@ class UpdateValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Edit')
-            ->missing('errors.acquisition_source')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Edit')
+                ->missing('errors.acquisition_source')
+                // ->dump()
         );
     }
 
     /** @test */
     public function 備品編集更新バリデーションacquisition_sourceが20文字の有効値()
-    {   
+    {
         $user = User::factory()->role(1)->create();
         $this->actingAs($user);
 
         $item = Item::factory()->create();
 
-        $response = $this->from('items/'.$item->id.'/edit')
+        $response = $this->from('items/' . $item->id . '/edit')
             ->put(route('items.update', $item), ['acquisition_source' => str_repeat('あ', 20)]);
 
         $response->assertRedirect(route('items.edit', ['item' => $item->id])); //URLにリダイレクト
@@ -1360,22 +1333,22 @@ class UpdateValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Edit')
-            ->missing('errors.acquisition_source')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Edit')
+                ->missing('errors.acquisition_source')
+                // ->dump()
         );
     }
 
     /** @test */
     public function 備品編集更新バリデーションacquisition_sourceが21文字の無効値()
-    {   
+    {
         $user = User::factory()->role(1)->create();
         $this->actingAs($user);
 
         $item = Item::factory()->create();
 
-        $response = $this->from('items/'.$item->id.'/edit')
+        $response = $this->from('items/' . $item->id . '/edit')
             ->put(route('items.update', $item), ['acquisition_source' => str_repeat('あ', 21)]);
 
         $response->assertRedirect(route('items.edit', ['item' => $item->id])); //URLにリダイレクト
@@ -1383,25 +1356,24 @@ class UpdateValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Edit')
-            ->has('errors.acquisition_source')
-            ->where('errors.acquisition_source', '取得先は、20文字以下で指定してください。')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Edit')
+                ->has('errors.acquisition_source')
+                ->where('errors.acquisition_source', '取得先は、20文字以下で指定してください。')
+                // ->dump()
         );
     }
-
 
     // priceのバリデーションのテスト
     /** @test */
     public function 備品編集更新バリデーションpriceが空欄で無効値()
-    {   
+    {
         $user = User::factory()->role(1)->create();
         $this->actingAs($user);
 
         $item = Item::factory()->create();
 
-        $response = $this->from('items/'.$item->id.'/edit')
+        $response = $this->from('items/' . $item->id . '/edit')
             ->put(route('items.update', $item), ['price' => '']);
 
         $response->assertRedirect(route('items.edit', ['item' => $item->id])); //URLにリダイレクト
@@ -1409,94 +1381,94 @@ class UpdateValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Edit')
-            ->has('errors.price')
-            ->where('errors.price', '価格は必ず指定してください。')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Edit')
+                ->has('errors.price')
+                ->where('errors.price', '価格は必ず指定してください。')
+                // ->dump()
         );
     }
 
     /** @test */
     public function 備品編集更新バリデーションpriceが文字列で無効値()
-    {   
+    {
         $user = User::factory()->role(1)->create();
         $this->actingAs($user);
 
         $item = Item::factory()->create();
 
-        $response = $this->from('items/'.$item->id.'/edit')
-            ->put(route('items.update', $item),  ['price' => 'あ']);
+        $response = $this->from('items/' . $item->id . '/edit')
+            ->put(route('items.update', $item), ['price' => 'あ']);
 
         $response->assertRedirect(route('items.edit', ['item' => $item->id])); //URLにリダイレクト
         $response->assertStatus(302);
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Edit')
-            ->has('errors.price')
-            ->where('errors.price', '価格は整数で指定してください。')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Edit')
+                ->has('errors.price')
+                ->where('errors.price', '価格は整数で指定してください。')
+                // ->dump()
         );
     }
 
     /** @test */
     public function 備品編集更新バリデーションpriceがマイナスの数値の無効値()
-    {   
+    {
         $user = User::factory()->role(1)->create();
         $this->actingAs($user);
 
         $item = Item::factory()->create();
 
-        $response = $this->from('items/'.$item->id.'/edit')
-            ->put(route('items.update', $item),  ['price' => -1]);
+        $response = $this->from('items/' . $item->id . '/edit')
+            ->put(route('items.update', $item), ['price' => -1]);
 
         $response->assertRedirect(route('items.edit', ['item' => $item->id])); //URLにリダイレクト
         $response->assertStatus(302);
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Edit')
-            ->has('errors.price')
-            ->where('errors.price', '価格には、0以上の数字を指定してください。')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Edit')
+                ->has('errors.price')
+                ->where('errors.price', '価格には、0以上の数字を指定してください。')
+                // ->dump()
         );
     }
 
     /** @test */
     public function 備品編集更新バリデーションpriceが0で最小の有効値()
-    {   
+    {
         $user = User::factory()->role(1)->create();
         $this->actingAs($user);
 
         $item = Item::factory()->create();
 
-        $response = $this->from('items/'.$item->id.'/edit')
-            ->put(route('items.update', $item),  ['price' => 0]);
+        $response = $this->from('items/' . $item->id . '/edit')
+            ->put(route('items.update', $item), ['price' => 0]);
 
         $response->assertRedirect(route('items.edit', ['item' => $item->id])); //URLにリダイレクト
         $response->assertStatus(302);
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Edit')
-            ->missing('errors.price')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Edit')
+                ->missing('errors.price')
+                // ->dump()
         );
     }
 
     /** @test */
     public function 備品編集更新バリデーションpriceが100万で最大の有効値()
-    {   
+    {
         $user = User::factory()->role(1)->create();
         $this->actingAs($user);
 
         $item = Item::factory()->create();
 
-        $response = $this->from('items/'.$item->id.'/edit')
+        $response = $this->from('items/' . $item->id . '/edit')
             ->put(route('items.update', $item), ['price' => 1000000]);
 
         $response->assertRedirect(route('items.edit', ['item' => $item->id])); //URLにリダイレクト
@@ -1504,22 +1476,22 @@ class UpdateValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Edit')
-            ->missing('errors.price')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Edit')
+                ->missing('errors.price')
+                // ->dump()
         );
     }
 
     /** @test */
     public function 備品編集更新バリデーションpriceが100万1で最大を超える無効値()
-    {   
+    {
         $user = User::factory()->role(1)->create();
         $this->actingAs($user);
 
         $item = Item::factory()->create();
 
-        $response = $this->from('items/'.$item->id.'/edit')
+        $response = $this->from('items/' . $item->id . '/edit')
             ->put(route('items.update', $item), ['price' => 1000001]);
 
         $response->assertRedirect(route('items.edit', ['item' => $item->id])); //URLにリダイレクト
@@ -1527,25 +1499,24 @@ class UpdateValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Edit')
-            ->has('errors.price')
-            ->where('errors.price', '価格には、1000000以下の数字を指定してください。')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Edit')
+                ->has('errors.price')
+                ->where('errors.price', '価格には、1000000以下の数字を指定してください。')
+                // ->dump()
         );
     }
-
 
     // date_of_acquisitionのバリデーションのテスト
     /** @test */
     public function 備品編集更新バリデーションdate_of_acquisitionが空で無効値()
-    {   
+    {
         $user = User::factory()->role(1)->create();
         $this->actingAs($user);
 
         $item = Item::factory()->create();
 
-        $response = $this->from('items/'.$item->id.'/edit')
+        $response = $this->from('items/' . $item->id . '/edit')
             ->put(route('items.update', $item), ['date_of_acquisition' => '']);
 
         $response->assertRedirect(route('items.edit', ['item' => $item->id])); //URLにリダイレクト
@@ -1553,17 +1524,17 @@ class UpdateValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Edit')
-            ->has('errors.date_of_acquisition')
-            ->where('errors.date_of_acquisition', '取得年月日は必ず指定してください。')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Edit')
+                ->has('errors.date_of_acquisition')
+                ->where('errors.date_of_acquisition', '取得年月日は必ず指定してください。')
+                // ->dump()
         );
     }
-    
+
     /** @test */
     public function 備品編集更新バリデーションdate_of_acquisitionが今日より未来の日付で無効値()
-    {   
+    {
         $user = User::factory()->role(1)->create();
         $this->actingAs($user);
 
@@ -1572,7 +1543,7 @@ class UpdateValidationTest extends TestCase
         // 今日より未来の日付を生成
         $tomorrow = Carbon::now()->addDays(1)->format('Y-m-d');
 
-        $response = $this->from('items/'.$item->id.'/edit')
+        $response = $this->from('items/' . $item->id . '/edit')
             ->put(route('items.update', $item), ['date_of_acquisition' => $tomorrow]);
 
         $response->assertRedirect(route('items.edit', ['item' => $item->id])); //URLにリダイレクト
@@ -1580,17 +1551,17 @@ class UpdateValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Edit')
-            ->has('errors.date_of_acquisition')
-            ->where('errors.date_of_acquisition', '取得年月日には、今日以前の日付をご利用ください。')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Edit')
+                ->has('errors.date_of_acquisition')
+                ->where('errors.date_of_acquisition', '取得年月日には、今日以前の日付をご利用ください。')
+                // ->dump()
         );
     }
-    
+
     /** @test */
     public function 備品編集更新バリデーションdate_of_acquisitionが今日当日で有効値()
-    {   
+    {
         $user = User::factory()->role(1)->create();
         $this->actingAs($user);
 
@@ -1599,7 +1570,7 @@ class UpdateValidationTest extends TestCase
         // 今日の日付
         $today = Carbon::now()->format('Y-m-d');
 
-        $response = $this->from('items/'.$item->id.'/edit')
+        $response = $this->from('items/' . $item->id . '/edit')
             ->put(route('items.update', $item), ['date_of_acquisition' => $today]);
 
         $response->assertRedirect(route('items.edit', ['item' => $item->id])); //URLにリダイレクト
@@ -1607,16 +1578,16 @@ class UpdateValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Edit')
-            ->missing('errors.date_of_acquisition')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Edit')
+                ->missing('errors.date_of_acquisition')
+                // ->dump()
         );
     }
-    
+
     /** @test */
     public function 備品編集更新バリデーションdate_of_acquisitionが今日より過去の日付で有効値()
-    {   
+    {
         $user = User::factory()->role(1)->create();
         $this->actingAs($user);
 
@@ -1625,7 +1596,7 @@ class UpdateValidationTest extends TestCase
         // 昨日の日付
         $yesterday = Carbon::now()->subDay()->format('Y-m-d');
 
-        $response = $this->from('items/'.$item->id.'/edit')
+        $response = $this->from('items/' . $item->id . '/edit')
             ->put(route('items.update', $item), ['date_of_acquisition' => $yesterday]);
 
         $response->assertRedirect(route('items.edit', ['item' => $item->id])); //URLにリダイレクト
@@ -1633,24 +1604,23 @@ class UpdateValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Edit')
-            ->missing('errors.date_of_acquisition')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Edit')
+                ->missing('errors.date_of_acquisition')
+                // ->dump()
         );
     }
-
 
     // manufacturerのバリデーションのテスト
     /** @test */
     public function 備品編集更新バリデーションmanufacturer空欄の有効値()
-    {   
+    {
         $user = User::factory()->role(1)->create();
         $this->actingAs($user);
 
         $item = Item::factory()->create();
 
-        $response = $this->from('items/'.$item->id.'/edit')
+        $response = $this->from('items/' . $item->id . '/edit')
             ->put(route('items.update', $item), ['manufacturer' => '']);
 
         $response->assertRedirect(route('items.edit', ['item' => $item->id])); //URLにリダイレクト
@@ -1658,22 +1628,22 @@ class UpdateValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Edit')
-            ->missing('errors.manufacturer')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Edit')
+                ->missing('errors.manufacturer')
+                // ->dump()
         );
     }
 
     /** @test */
     public function 備品編集更新バリデーションmanufacturer1文字の有効値()
-    {   
+    {
         $user = User::factory()->role(1)->create();
         $this->actingAs($user);
 
         $item = Item::factory()->create();
 
-        $response = $this->from('items/'.$item->id.'/edit')
+        $response = $this->from('items/' . $item->id . '/edit')
             ->put(route('items.update', $item), ['manufacturer' => str_repeat('あ', 1)]);
 
         $response->assertRedirect(route('items.edit', ['item' => $item->id])); //URLにリダイレクト
@@ -1681,22 +1651,22 @@ class UpdateValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Edit')
-            ->missing('errors.manufacturer')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Edit')
+                ->missing('errors.manufacturer')
+                // ->dump()
         );
     }
 
     /** @test */
     public function 備品編集更新バリデーションmanufacturer20文字で最大の有効値()
-    {   
+    {
         $user = User::factory()->role(1)->create();
         $this->actingAs($user);
 
         $item = Item::factory()->create();
 
-        $response = $this->from('items/'.$item->id.'/edit')
+        $response = $this->from('items/' . $item->id . '/edit')
             ->put(route('items.update', $item), ['manufacturer' => str_repeat('あ', 20)]);
 
         $response->assertRedirect(route('items.edit', ['item' => $item->id])); //URLにリダイレクト
@@ -1704,22 +1674,22 @@ class UpdateValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Edit')
-            ->missing('errors.manufacturer')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Edit')
+                ->missing('errors.manufacturer')
+                // ->dump()
         );
     }
 
     /** @test */
     public function 備品編集更新バリデーションmanufacturer21文字で最大を超える無効値()
-    {   
+    {
         $user = User::factory()->role(1)->create();
         $this->actingAs($user);
 
         $item = Item::factory()->create();
 
-        $response = $this->from('items/'.$item->id.'/edit')
+        $response = $this->from('items/' . $item->id . '/edit')
             ->put(route('items.update', $item), ['manufacturer' => str_repeat('あ', 21)]);
 
         $response->assertRedirect(route('items.edit', ['item' => $item->id])); //URLにリダイレクト
@@ -1727,25 +1697,24 @@ class UpdateValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Edit')
-            ->has('errors.manufacturer')
-            ->where('errors.manufacturer', 'メーカーは、20文字以下で指定してください。')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Edit')
+                ->has('errors.manufacturer')
+                ->where('errors.manufacturer', 'メーカーは、20文字以下で指定してください。')
+                // ->dump()
         );
     }
-
 
     // product_numberのバリデーションのテスト
     /** @test */
     public function 備品編集更新バリデーションproduct_number空欄で有効値()
-    {   
+    {
         $user = User::factory()->role(1)->create();
         $this->actingAs($user);
 
         $item = Item::factory()->create();
 
-        $response = $this->from('items/'.$item->id.'/edit')
+        $response = $this->from('items/' . $item->id . '/edit')
             ->put(route('items.update', $item), ['product_number' => '']);
 
         $response->assertRedirect(route('items.edit', ['item' => $item->id])); //URLにリダイレクト
@@ -1753,22 +1722,22 @@ class UpdateValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Edit')
-            ->missing('errors.product_number')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Edit')
+                ->missing('errors.product_number')
+                // ->dump()
         );
     }
 
     /** @test */
     public function 備品編集更新バリデーションproduct_number1文字の有効値()
-    {   
+    {
         $user = User::factory()->role(1)->create();
         $this->actingAs($user);
 
         $item = Item::factory()->create();
 
-        $response = $this->from('items/'.$item->id.'/edit')
+        $response = $this->from('items/' . $item->id . '/edit')
             ->put(route('items.update', $item), ['product_number' => str_repeat('あ', 1)]);
 
         $response->assertRedirect(route('items.edit', ['item' => $item->id])); //URLにリダイレクト
@@ -1776,22 +1745,22 @@ class UpdateValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Edit')
-            ->missing('errors.product_number')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Edit')
+                ->missing('errors.product_number')
+                // ->dump()
         );
     }
 
     /** @test */
     public function 備品編集更新バリデーションproduct_number31文字で最大を超える無効値()
-    {   
+    {
         $user = User::factory()->role(1)->create();
         $this->actingAs($user);
 
         $item = Item::factory()->create();
 
-        $response = $this->from('items/'.$item->id.'/edit')
+        $response = $this->from('items/' . $item->id . '/edit')
             ->put(route('items.update', $item), ['product_number' => str_repeat('あ', 31)]);
 
         $response->assertRedirect(route('items.edit', ['item' => $item->id])); //URLにリダイレクト
@@ -1799,25 +1768,24 @@ class UpdateValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Edit')
-            ->has('errors.product_number')
-            ->where('errors.product_number', '製品番号は、30文字以下で指定してください。')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Edit')
+                ->has('errors.product_number')
+                ->where('errors.product_number', '製品番号は、30文字以下で指定してください。')
+                // ->dump()
         );
     }
-
 
     // remarksのバリデーションのテスト
     /** @test */
     public function 備品編集更新バリデーションremarks空欄の有効値()
-    {   
+    {
         $user = User::factory()->role(1)->create();
         $this->actingAs($user);
 
         $item = Item::factory()->create();
 
-        $response = $this->from('items/'.$item->id.'/edit')
+        $response = $this->from('items/' . $item->id . '/edit')
             ->put(route('items.update', $item), ['remarks' => '']);
 
         $response->assertRedirect(route('items.edit', ['item' => $item->id])); //URLにリダイレクト
@@ -1825,22 +1793,22 @@ class UpdateValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Edit')
-            ->missing('errors.remarks')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Edit')
+                ->missing('errors.remarks')
+                // ->dump()
         );
     }
 
     /** @test */
     public function 備品編集更新バリデーションremarks1文字の有効値()
-    {   
+    {
         $user = User::factory()->role(1)->create();
         $this->actingAs($user);
 
         $item = Item::factory()->create();
 
-        $response = $this->from('items/'.$item->id.'/edit')
+        $response = $this->from('items/' . $item->id . '/edit')
             ->put(route('items.update', $item), ['remarks' => str_repeat('あ', 1)]);
 
         $response->assertRedirect(route('items.edit', ['item' => $item->id])); //URLにリダイレクト
@@ -1848,22 +1816,22 @@ class UpdateValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Edit')
-            ->missing('errors.remarks')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Edit')
+                ->missing('errors.remarks')
+                // ->dump()
         );
     }
 
     /** @test */
     public function 備品編集更新バリデーションremarks501文字で最大を超える無効値()
-    {   
+    {
         $user = User::factory()->role(1)->create();
         $this->actingAs($user);
 
         $item = Item::factory()->create();
 
-        $response = $this->from('items/'.$item->id.'/edit')
+        $response = $this->from('items/' . $item->id . '/edit')
             ->put(route('items.update', $item), ['remarks' => str_repeat('あ', 501)]);
 
         $response->assertRedirect(route('items.edit', ['item' => $item->id])); //URLにリダイレクト
@@ -1871,25 +1839,24 @@ class UpdateValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Edit')
-            ->has('errors.remarks')
-            ->where('errors.remarks', '備考は、500文字以下で指定してください。')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Edit')
+                ->has('errors.remarks')
+                ->where('errors.remarks', '備考は、500文字以下で指定してください。')
+                // ->dump()
         );
     }
-
 
     // inspection_scheduled_dateのバリデーションのテスト
     /** @test */
     public function 備品編集更新バリデーションinspection_scheduled_dateが空で有効値()
-    {   
+    {
         $user = User::factory()->role(1)->create();
         $this->actingAs($user);
 
         $item = Item::factory()->create();
 
-        $response = $this->from('items/'.$item->id.'/edit')
+        $response = $this->from('items/' . $item->id . '/edit')
             ->put(route('items.update', $item), ['inspection_scheduled_date' => '']);
 
         $response->assertRedirect(route('items.edit', ['item' => $item->id])); //URLにリダイレクト
@@ -1897,16 +1864,16 @@ class UpdateValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Edit')
-            ->missing('errors.inspection_scheduled_date')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Edit')
+                ->missing('errors.inspection_scheduled_date')
+                // ->dump()
         );
     }
 
     /** @test */
     public function 備品編集更新バリデーションinspection_scheduled_dateが今日より過去の日付で無効値()
-    {   
+    {
         $user = User::factory()->role(1)->create();
         $this->actingAs($user);
 
@@ -1917,10 +1884,10 @@ class UpdateValidationTest extends TestCase
         // 昨日の日付
         $yesterday = Carbon::now()->subDay()->format('Y-m-d');
 
-        $response = $this->from('items/'.$item->id.'/edit')
+        $response = $this->from('items/' . $item->id . '/edit')
             ->put(route('items.update', $item), [
-                'date_of_acquisition' => $date_of_acquisition,
-                'inspection_scheduled_date' => $yesterday
+                'date_of_acquisition'       => $date_of_acquisition,
+                'inspection_scheduled_date' => $yesterday,
             ]);
 
         $response->assertRedirect(route('items.edit', ['item' => $item->id])); //URLにリダイレクト
@@ -1928,17 +1895,17 @@ class UpdateValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Edit')
-            ->has('errors.inspection_scheduled_date')
-            ->where('errors.inspection_scheduled_date', '点検予定日は取得年月日以降の日付を入力してください')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Edit')
+                ->has('errors.inspection_scheduled_date')
+                ->where('errors.inspection_scheduled_date', '点検予定日は取得年月日以降の日付を入力してください')
+                // ->dump()
         );
     }
-    
+
     /** @test */
     public function 備品編集更新バリデーションinspection_scheduled_dateが今日当日で有効値()
-    {   
+    {
         $user = User::factory()->role(1)->create();
         $this->actingAs($user);
 
@@ -1949,10 +1916,10 @@ class UpdateValidationTest extends TestCase
         // 今日の日付
         $today = Carbon::now()->format('Y-m-d');
 
-        $response = $this->from('items/'.$item->id.'/edit')
+        $response = $this->from('items/' . $item->id . '/edit')
             ->put(route('items.update', $item), [
-                'date_of_acquisition' => $date_of_acquisition,
-                'inspection_scheduled_date' => $today
+                'date_of_acquisition'       => $date_of_acquisition,
+                'inspection_scheduled_date' => $today,
             ]);
 
         $response->assertRedirect(route('items.edit', ['item' => $item->id])); //URLにリダイレクト
@@ -1960,16 +1927,16 @@ class UpdateValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Edit')
-            ->missing('errors.inspection_scheduled_date')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Edit')
+                ->missing('errors.inspection_scheduled_date')
+                // ->dump()
         );
     }
-    
+
     /** @test */
     public function 備品編集更新バリデーションinspection_scheduled_dateがdate_of_acquisitionから3年以内で有効値()
-    {   
+    {
         $user = User::factory()->role(1)->create();
         $this->actingAs($user);
 
@@ -1980,10 +1947,10 @@ class UpdateValidationTest extends TestCase
         // 3年後の日付
         $threeYearsLater = Carbon::now()->addYears(3)->format('Y-m-d');
 
-        $response = $this->from('items/'.$item->id.'/edit')
+        $response = $this->from('items/' . $item->id . '/edit')
             ->put(route('items.update', $item), [
-                'date_of_acquisition' => $date_of_acquisition,
-                'inspection_scheduled_date' => $threeYearsLater
+                'date_of_acquisition'       => $date_of_acquisition,
+                'inspection_scheduled_date' => $threeYearsLater,
             ]);
 
         $response->assertRedirect(route('items.edit', ['item' => $item->id])); //URLにリダイレクト
@@ -1991,16 +1958,16 @@ class UpdateValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Edit')
-            ->missing('errors.inspection_scheduled_date')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Edit')
+                ->missing('errors.inspection_scheduled_date')
+                // ->dump()
         );
     }
-    
+
     /** @test */
     public function 備品編集更新バリデーションinspection_scheduled_dateがdate_of_acquisitionから3年と1日後で無効値()
-    {   
+    {
         $user = User::factory()->role(1)->create();
         $this->actingAs($user);
 
@@ -2011,10 +1978,10 @@ class UpdateValidationTest extends TestCase
         // 3年と1日後の日付
         $threeYearsAndOneDayLater = Carbon::now()->addYears(3)->addDay()->format('Y-m-d');
 
-        $response = $this->from('items/'.$item->id.'/edit')
+        $response = $this->from('items/' . $item->id . '/edit')
             ->put(route('items.update', $item), [
-                'date_of_acquisition' => $date_of_acquisition,
-                'inspection_scheduled_date' => $threeYearsAndOneDayLater
+                'date_of_acquisition'       => $date_of_acquisition,
+                'inspection_scheduled_date' => $threeYearsAndOneDayLater,
             ]);
 
         $response->assertRedirect(route('items.edit', ['item' => $item->id])); //URLにリダイレクト
@@ -2022,26 +1989,24 @@ class UpdateValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Edit')
-            ->has('errors.inspection_scheduled_date')
-            ->where('errors.inspection_scheduled_date', '点検予定日は取得年月日から3年以内の日付を入力してください')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Edit')
+                ->has('errors.inspection_scheduled_date')
+                ->where('errors.inspection_scheduled_date', '点検予定日は取得年月日から3年以内の日付を入力してください')
+                // ->dump()
         );
     }
-
-
 
     // disposal_scheduled_dateのバリデーションのテスト
     /** @test */
     public function 備品編集更新バリデーションdisposal_scheduled_dateが空で有効値()
-    {   
+    {
         $user = User::factory()->role(1)->create();
         $this->actingAs($user);
 
         $item = Item::factory()->create();
 
-        $response = $this->from('items/'.$item->id.'/edit')
+        $response = $this->from('items/' . $item->id . '/edit')
             ->put(route('items.update', $item), ['disposal_scheduled_date' => '']);
 
         $response->assertRedirect(route('items.edit', ['item' => $item->id])); //URLにリダイレクト
@@ -2049,16 +2014,16 @@ class UpdateValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Edit')
-            ->missing('errors.disposal_scheduled_date')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Edit')
+                ->missing('errors.disposal_scheduled_date')
+                // ->dump()
         );
     }
 
     /** @test */
     public function 備品編集更新バリデーションdisposal_scheduled_dateが今日より過去の日付で無効値()
-    {   
+    {
         $user = User::factory()->role(1)->create();
         $this->actingAs($user);
 
@@ -2069,10 +2034,10 @@ class UpdateValidationTest extends TestCase
         // 昨日の日付
         $yesterday = Carbon::now()->subDay()->format('Y-m-d');
 
-        $response = $this->from('items/'.$item->id.'/edit')
+        $response = $this->from('items/' . $item->id . '/edit')
             ->put(route('items.update', $item), [
-                'date_of_acquisition' => $date_of_acquisition,
-                'disposal_scheduled_date' => $yesterday
+                'date_of_acquisition'     => $date_of_acquisition,
+                'disposal_scheduled_date' => $yesterday,
             ]);
 
         $response->assertRedirect(route('items.edit', ['item' => $item->id])); //URLにリダイレクト
@@ -2080,17 +2045,17 @@ class UpdateValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Edit')
-            ->has('errors.disposal_scheduled_date')
-            ->where('errors.disposal_scheduled_date', '廃棄予定日は取得年月日以降の日付を入力してください')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Edit')
+                ->has('errors.disposal_scheduled_date')
+                ->where('errors.disposal_scheduled_date', '廃棄予定日は取得年月日以降の日付を入力してください')
+                // ->dump()
         );
     }
 
     /** @test */
     public function 備品編集更新バリデーションdisposal_scheduled_dateが今日当日で有効値()
-    {   
+    {
         $user = User::factory()->role(1)->create();
         $this->actingAs($user);
 
@@ -2101,10 +2066,10 @@ class UpdateValidationTest extends TestCase
         // 今日の日付
         $today = Carbon::now()->format('Y-m-d');
 
-        $response = $this->from('items/'.$item->id.'/edit')
+        $response = $this->from('items/' . $item->id . '/edit')
             ->put(route('items.update', $item), [
-                'date_of_acquisition' => $date_of_acquisition,
-                'disposal_scheduled_date' => $today
+                'date_of_acquisition'     => $date_of_acquisition,
+                'disposal_scheduled_date' => $today,
             ]);
 
         $response->assertRedirect(route('items.edit', ['item' => $item->id])); //URLにリダイレクト
@@ -2112,16 +2077,16 @@ class UpdateValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Edit')
-            ->missing('errors.disposal_scheduled_date')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Edit')
+                ->missing('errors.disposal_scheduled_date')
+                // ->dump()
         );
     }
 
     /** @test */
     public function 備品編集更新バリデーションdisposal_scheduled_dateがdate_of_acquisitionから3年以内で有効値()
-    {   
+    {
         $user = User::factory()->role(1)->create();
         $this->actingAs($user);
 
@@ -2132,10 +2097,10 @@ class UpdateValidationTest extends TestCase
         // 3年後の日付
         $threeYearsLater = Carbon::now()->addYears(3)->format('Y-m-d');
 
-        $response = $this->from('items/'.$item->id.'/edit')
+        $response = $this->from('items/' . $item->id . '/edit')
             ->put(route('items.update', $item), [
-                'date_of_acquisition' => $date_of_acquisition,
-                'disposal_scheduled_date' => $threeYearsLater 
+                'date_of_acquisition'     => $date_of_acquisition,
+                'disposal_scheduled_date' => $threeYearsLater,
             ]);
 
         $response->assertRedirect(route('items.edit', ['item' => $item->id])); //URLにリダイレクト
@@ -2143,16 +2108,16 @@ class UpdateValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Edit')
-            ->missing('errors.disposal_scheduled_date')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Edit')
+                ->missing('errors.disposal_scheduled_date')
+                // ->dump()
         );
     }
 
     /** @test */
     public function 備品編集更新バリデーションdisposal_scheduled_dateがdate_of_acquisitionから3年と1日後で無効値()
-    {   
+    {
         $user = User::factory()->role(1)->create();
         $this->actingAs($user);
 
@@ -2163,10 +2128,10 @@ class UpdateValidationTest extends TestCase
         // 3年と1日後の日付
         $threeYearsAndOneDayLater = Carbon::now()->addYears(3)->addDay()->format('Y-m-d');
 
-        $response = $this->from('items/'.$item->id.'/edit')
+        $response = $this->from('items/' . $item->id . '/edit')
             ->put(route('items.update', $item), [
-                'date_of_acquisition' => $date_of_acquisition,
-                'disposal_scheduled_date' => $threeYearsAndOneDayLater 
+                'date_of_acquisition'     => $date_of_acquisition,
+                'disposal_scheduled_date' => $threeYearsAndOneDayLater,
             ]);
 
         $response->assertRedirect(route('items.edit', ['item' => $item->id])); //URLにリダイレクト
@@ -2174,20 +2139,18 @@ class UpdateValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Edit')
-            ->has('errors.disposal_scheduled_date')
-            ->where('errors.disposal_scheduled_date', '廃棄予定日は取得年月日から3年以内の日付を入力してください')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Edit')
+                ->has('errors.disposal_scheduled_date')
+                ->where('errors.disposal_scheduled_date', '廃棄予定日は取得年月日から3年以内の日付を入力してください')
+                // ->dump()
         );
     }
-
-
 
     // edit_reason_idのバリデーションのテスト
     /** @test */
     public function 備品編集更新バリデーションedit_reason_idが最小値より小さい無効値()
-    {   
+    {
         // 世界を構築
         $edit_reasons = EditReason::factory()->count(5)->create();
 
@@ -2196,7 +2159,7 @@ class UpdateValidationTest extends TestCase
 
         $item = Item::factory()->create();
 
-        $response = $this->from('items/'.$item->id.'/edit')
+        $response = $this->from('items/' . $item->id . '/edit')
             ->put(route('items.update', $item), ['edit_reason_id' => 0]);
 
         $response->assertRedirect(route('items.edit', ['item' => $item->id])); //URLにリダイレクト
@@ -2204,17 +2167,17 @@ class UpdateValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Edit')
-            ->has('errors.edit_reason_id')
-            ->where('errors.edit_reason_id', '選択された編集理由は正しくありません。')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Edit')
+                ->has('errors.edit_reason_id')
+                ->where('errors.edit_reason_id', '選択された編集理由は正しくありません。')
+                // ->dump()
         );
     }
 
     /** @test */
     public function 備品編集更新バリデーションedit_reason_idが最小値の有効値()
-    {   
+    {
         // 世界を構築
         $edit_reasons = EditReason::factory()->count(5)->create();
 
@@ -2223,7 +2186,7 @@ class UpdateValidationTest extends TestCase
 
         $item = Item::factory()->create();
 
-        $response = $this->from('items/'.$item->id.'/edit')
+        $response = $this->from('items/' . $item->id . '/edit')
             ->put(route('items.update', $item), ['edit_reason_id' => $edit_reasons->min('id')]);
 
         $response->assertRedirect(route('items.edit', ['item' => $item->id])); //URLにリダイレクト
@@ -2231,16 +2194,16 @@ class UpdateValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Edit')
-            ->missing('errors.edit_reason_id')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Edit')
+                ->missing('errors.edit_reason_id')
+                // ->dump()
         );
     }
 
     /** @test */
     public function 備品編集更新バリデーションedit_reason_idが最大値の有効値()
-    {   
+    {
         // 世界を構築
         $edit_reasons = EditReason::factory()->count(5)->create();
 
@@ -2249,7 +2212,7 @@ class UpdateValidationTest extends TestCase
 
         $item = Item::factory()->create();
 
-        $response = $this->from('items/'.$item->id.'/edit')
+        $response = $this->from('items/' . $item->id . '/edit')
             ->put(route('items.update', $item), ['edit_reason_id' => $edit_reasons->max('id')]);
 
         $response->assertRedirect(route('items.edit', ['item' => $item->id])); //URLにリダイレクト
@@ -2257,16 +2220,16 @@ class UpdateValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Edit')
-            ->missing('errors.edit_reason_id')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Edit')
+                ->missing('errors.edit_reason_id')
+                // ->dump()
         );
     }
 
     /** @test */
     public function 備品編集更新バリデーションedit_reason_idが最大値より大きい無効値()
-    {   
+    {
         // 世界を構築
         $edit_reasons = EditReason::factory()->count(5)->create();
 
@@ -2276,7 +2239,7 @@ class UpdateValidationTest extends TestCase
         // EditReasonはItemのカラムでないので、自動インクリメントされない
         $item = Item::factory()->create();
 
-        $response = $this->from('items/'.$item->id.'/edit')
+        $response = $this->from('items/' . $item->id . '/edit')
             ->put(route('items.update', $item), ['edit_reason_id' => $edit_reasons->max('id') + 1]);
 
         $response->assertRedirect(route('items.edit', ['item' => $item->id])); //URLにリダイレクト
@@ -2284,25 +2247,24 @@ class UpdateValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Edit')
-            ->has('errors.edit_reason_id')
-            ->where('errors.edit_reason_id', '選択された編集理由は正しくありません。')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Edit')
+                ->has('errors.edit_reason_id')
+                ->where('errors.edit_reason_id', '選択された編集理由は正しくありません。')
+                // ->dump()
         );
     }
-
 
     // edit_reason_textのバリデーションテスト
     /** @test */
     public function 備品編集更新バリデーションedit_reason_text空欄の有効値()
-    {   
+    {
         $user = User::factory()->role(1)->create();
         $this->actingAs($user);
 
         $item = Item::factory()->create();
 
-        $response = $this->from('items/'.$item->id.'/edit')
+        $response = $this->from('items/' . $item->id . '/edit')
             ->put(route('items.update', $item), ['edit_reason_text' => '']);
 
         $response->assertRedirect(route('items.edit', ['item' => $item->id])); //URLにリダイレクト
@@ -2310,22 +2272,22 @@ class UpdateValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Edit')
-            ->missing('errors.edit_reason_text')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Edit')
+                ->missing('errors.edit_reason_text')
+                // ->dump()
         );
     }
 
     /** @test */
     public function 備品編集更新バリデーションedit_reason_text1文字の有効値()
-    {   
+    {
         $user = User::factory()->role(1)->create();
         $this->actingAs($user);
 
         $item = Item::factory()->create();
 
-        $response = $this->from('items/'.$item->id.'/edit')
+        $response = $this->from('items/' . $item->id . '/edit')
             ->put(route('items.update', $item), ['edit_reason_text' => str_repeat('あ', 1)]);
 
         $response->assertRedirect(route('items.edit', ['item' => $item->id])); //URLにリダイレクト
@@ -2333,22 +2295,22 @@ class UpdateValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Edit')
-            ->missing('errors.edit_reason_text')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Edit')
+                ->missing('errors.edit_reason_text')
+                // ->dump()
         );
     }
 
     /** @test */
     public function 備品編集更新バリデーションedit_reason_text200文字の有効値()
-    {   
+    {
         $user = User::factory()->role(1)->create();
         $this->actingAs($user);
 
         $item = Item::factory()->create();
 
-        $response = $this->from('items/'.$item->id.'/edit')
+        $response = $this->from('items/' . $item->id . '/edit')
             ->put(route('items.update', $item), ['edit_reason_text' => str_repeat('あ', 200)]);
 
         $response->assertRedirect(route('items.edit', ['item' => $item->id])); //URLにリダイレクト
@@ -2356,22 +2318,22 @@ class UpdateValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Edit')
-            ->missing('errors.edit_reason_text')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Edit')
+                ->missing('errors.edit_reason_text')
+                // ->dump()
         );
     }
 
     /** @test */
     public function 備品編集更新バリデーションedit_reason_text201文字の無効値()
-    {   
+    {
         $user = User::factory()->role(1)->create();
         $this->actingAs($user);
 
         $item = Item::factory()->create();
 
-        $response = $this->from('items/'.$item->id.'/edit')
+        $response = $this->from('items/' . $item->id . '/edit')
             ->put(route('items.update', $item), ['edit_reason_text' => str_repeat('あ', 201)]);
 
         $response->assertRedirect(route('items.edit', ['item' => $item->id])); //URLにリダイレクト
@@ -2379,11 +2341,11 @@ class UpdateValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Items/Edit')
-            ->has('errors.edit_reason_text')
-            ->where('errors.edit_reason_text', '理由詳細は、200文字以下で指定してください。')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Items/Edit')
+                ->has('errors.edit_reason_text')
+                ->where('errors.edit_reason_text', '理由詳細は、200文字以下で指定してください。')
+                // ->dump()
         );
     }
 }

--- a/tests/Feature/Http/Controllers/ItemRequestController/Create/CreateMethodTest.php
+++ b/tests/Feature/Http/Controllers/ItemRequestController/Create/CreateMethodTest.php
@@ -2,37 +2,10 @@
 
 namespace Tests\Feature\Http\Controllers\ItemRequestController\Create;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
-use Tests\TestCase;
 use App\Models\User;
-use App\Models\Item;
-use App\Models\Unit;
-use App\Models\Category;
-use App\Models\Location;
-use App\Models\UsageStatus;
-use App\Models\AcquisitionMethod;
-use App\Models\Edithistory;
-use App\Models\Inspection;
-use App\Models\EditReason;
-use App\Models\RequestStatus;
-use App\Models\StockTransaction;
-use App\Services\ImageService;
 use Faker\Factory as FakerFactory;
-use Inertia\Testing\AssertableInertia as Assert;
-use Mockery;
-use App\Services\ManagementIdService;
-use Illuminate\Support\Facades\Auth;
-use Carbon\Carbon;
-use Illuminate\Database\Console\DumpCommand;
-use Illuminate\Testing\Fluent\AssertableJson;
-use Inertia\Inertia;
-use Illuminate\Http\UploadedFile;
-use Illuminate\Support\Facades\Storage;
-use Intervention\Image\ImageManager;
-// use Intervention\Image\Drivers\Gd\Driver;
-use Intervention\Image\Drivers\Imagick\Driver;
-use Illuminate\Support\Facades\Session;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
 
 class CreateMethodTest extends TestCase
 {
@@ -47,18 +20,17 @@ class CreateMethodTest extends TestCase
 
     protected function tearDown(): void
     {
-        // 子クラスでのクリーンアップ処理
         parent::tearDown();
     }
 
     /** @test */
-    function リクエスト登録画面を開く()
+    public function リクエスト登録画面を開く()
     {
         // 全ての権限で画面を開く
         $roles = [
             'admin' => 1,
             'staff' => 5,
-            'user' => 9,
+            'user'  => 9,
         ];
 
         foreach ($roles as $roleName => $role) {

--- a/tests/Feature/Http/Controllers/ItemRequestController/Destroy/DestroyMethodTest.php
+++ b/tests/Feature/Http/Controllers/ItemRequestController/Destroy/DestroyMethodTest.php
@@ -2,13 +2,11 @@
 
 namespace Tests\Feature\Http\Controllers\ItemRequestController\Destroy;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
-use Tests\TestCase;
-use Faker\Factory as FakerFactory;
-use Inertia\Testing\AssertableInertia as Assert;
-use App\Models\User;
 use App\Models\ItemRequest;
+use App\Models\User;
+use Faker\Factory as FakerFactory;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
 
 class DestroyMethodTest extends TestCase
 {
@@ -23,12 +21,11 @@ class DestroyMethodTest extends TestCase
 
     protected function tearDown(): void
     {
-        // 子クラスでのクリーンアップ処理
         parent::tearDown();
     }
 
     /** @test */
-    function リクエストが削除できる()
+    public function リクエストが削除できる()
     {
         $itemRequest = ItemRequest::factory()->create();
 
@@ -40,7 +37,7 @@ class DestroyMethodTest extends TestCase
 
         $response->assertSessionHas([
             'message' => 'リクエストを削除しました',
-            'status' => 'danger'
+            'status'  => 'danger',
         ]);
 
         // データベースの検証

--- a/tests/Feature/Http/Controllers/ItemRequestController/Store/StoreMethodTest.php
+++ b/tests/Feature/Http/Controllers/ItemRequestController/Store/StoreMethodTest.php
@@ -2,39 +2,14 @@
 
 namespace Tests\Feature\Http\Controllers\ItemRequestController\Store;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
-use Tests\TestCase;
-use App\Models\User;
-use App\Models\Item;
-use App\Models\Unit;
 use App\Models\Category;
 use App\Models\Location;
-use App\Models\UsageStatus;
-use App\Models\AcquisitionMethod;
-use App\Models\Edithistory;
-use App\Models\Inspection;
-use App\Models\EditReason;
 use App\Models\RequestStatus;
-use App\Models\StockTransaction;
-use App\Services\ImageService;
+use App\Models\User;
 use Faker\Factory as FakerFactory;
-use Inertia\Testing\AssertableInertia as Assert;
-use Mockery;
-use App\Services\ManagementIdService;
-use Illuminate\Support\Facades\Auth;
-use Carbon\Carbon;
-use Illuminate\Database\Console\DumpCommand;
-use Illuminate\Testing\Fluent\AssertableJson;
-use Inertia\Inertia;
-use Illuminate\Http\UploadedFile;
-use Illuminate\Support\Facades\Storage;
-use Intervention\Image\ImageManager;
-// use Intervention\Image\Drivers\Gd\Driver;
-use Intervention\Image\Drivers\Imagick\Driver;
-use Illuminate\Support\Facades\Session;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
-
+use Tests\TestCase;
 
 class StoreMethodTest extends TestCase
 {
@@ -53,57 +28,55 @@ class StoreMethodTest extends TestCase
 
     protected function tearDown(): void
     {
-        // 子クラスでのクリーンアップ処理
         parent::tearDown();
     }
 
     /** @test */
-    function リクエストの登録が出来る()
+    public function リクエストの登録が出来る()
     {
         // テーブルのデータとIDをリセット
         //世界の構築
-        $categories = Category::factory()->count(11)->create();
-        $locations = Location::factory()->count(12)->create();
+        $categories      = Category::factory()->count(11)->create();
+        $locations       = Location::factory()->count(12)->create();
         $requet_statuses = RequestStatus::factory(4)->create();
-        
 
         // adminユーザーを作成
         $user = User::factory()->role(1)->create();
-        $this->actingAs($user);   
+        $this->actingAs($user);
 
         // ※注意
         // フロントから送られてくるデータを適切に模倣しないといけいない
         $validData = [
-            'name' => 'ボールペン',
-            'category_id' => $categories->first()->id,
-            'location_of_use_id' => $locations->first()->id,
-            'requestor' => '山田',
+            'name'                   => 'ボールペン',
+            'category_id'            => $categories->first()->id,
+            'location_of_use_id'     => $locations->first()->id,
+            'requestor'              => '山田',
             'remarks_from_requestor' => '申請理由です',
-            'request_status_id' => $requet_statuses->first()->id,
-            'manufacturer' => 'ボールペン工房',
-            'reference' => '参考サイト',
-            'price' => 100,
+            'request_status_id'      => $requet_statuses->first()->id,
+            'manufacturer'           => 'ボールペン工房',
+            'reference'              => '参考サイト',
+            'price'                  => 100,
         ];
-    
+
         $response = $this->from('item_requests/create')
             ->post(route('item_requests.store'), $validData);
 
         // フラッシュメッセージの確認
         $response->assertSessionHas('message', 'リクエストしました。');
         $response->assertSessionHas('status', 'success');
-            
+
         $response->assertRedirect(route('item_requests.index'));
 
         $this->assertDatabaseHas('item_requests', [
-            'name' => 'ボールペン',
-            'category_id' => $categories->first()->id,
-            'location_of_use_id' => $locations->first()->id,
-            'requestor' => '山田',
+            'name'                   => 'ボールペン',
+            'category_id'            => $categories->first()->id,
+            'location_of_use_id'     => $locations->first()->id,
+            'requestor'              => '山田',
             'remarks_from_requestor' => '申請理由です',
-            'request_status_id' => $requet_statuses->first()->id,
-            'manufacturer' => 'ボールペン工房',
-            'reference' => '参考サイト',
-            'price' => 100,
+            'request_status_id'      => $requet_statuses->first()->id,
+            'manufacturer'           => 'ボールペン工房',
+            'reference'              => '参考サイト',
+            'price'                  => 100,
         ]);
     }
 }

--- a/tests/Feature/Http/Controllers/ItemRequestController/Store/StoreValidationTest.php
+++ b/tests/Feature/Http/Controllers/ItemRequestController/Store/StoreValidationTest.php
@@ -1,39 +1,14 @@
 <?php
-
 namespace Tests\Feature\Http\Controllers\ItemRequestController\Store;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
-use Tests\TestCase;
-use App\Models\User;
-use App\Models\Item;
-use App\Models\Unit;
 use App\Models\Category;
 use App\Models\Location;
-use App\Models\UsageStatus;
-use App\Models\AcquisitionMethod;
-use App\Models\Edithistory;
-use App\Models\Inspection;
-use App\Models\EditReason;
-use App\Models\RequestStatus;
-use App\Models\StockTransaction;
-use App\Services\ImageService;
+use App\Models\User;
 use Faker\Factory as FakerFactory;
-use Inertia\Testing\AssertableInertia as Assert;
-use Mockery;
-use App\Services\ManagementIdService;
-use Illuminate\Support\Facades\Auth;
-use Carbon\Carbon;
-use Illuminate\Database\Console\DumpCommand;
-use Illuminate\Testing\Fluent\AssertableJson;
-use Inertia\Inertia;
-use Illuminate\Http\UploadedFile;
-use Illuminate\Support\Facades\Storage;
-use Intervention\Image\ImageManager;
-// use Intervention\Image\Drivers\Gd\Driver;
-use Intervention\Image\Drivers\Imagick\Driver;
-use Illuminate\Support\Facades\Session;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
+use Inertia\Testing\AssertableInertia as Assert;
+use Tests\TestCase;
 
 class StoreValidationTest extends TestCase
 {
@@ -53,7 +28,6 @@ class StoreValidationTest extends TestCase
 
     protected function tearDown(): void
     {
-        // 子クラスでのクリーンアップ処理
         parent::tearDown();
     }
 
@@ -72,11 +46,11 @@ class StoreValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('ItemRequests/Create')
-            ->has('errors.name')
-            ->where('errors.name', '名前は必ず指定してください。')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('ItemRequests/Create')
+                ->has('errors.name')
+                ->where('errors.name', '名前は必ず指定してください。')
+                // ->dump()
         );
     }
 
@@ -94,10 +68,10 @@ class StoreValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('ItemRequests/Create')
-            ->missing('errors.name')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('ItemRequests/Create')
+                ->missing('errors.name')
+                // ->dump()
         );
     }
 
@@ -115,10 +89,10 @@ class StoreValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('ItemRequests/Create')
-            ->missing('errors.name')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('ItemRequests/Create')
+                ->missing('errors.name')
+                // ->dump()
         );
     }
 
@@ -136,14 +110,13 @@ class StoreValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('ItemRequests/Create')
-            ->has('errors.name')
-            ->where('errors.name', '名前は、40文字以下で指定してください。')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('ItemRequests/Create')
+                ->has('errors.name')
+                ->where('errors.name', '名前は、40文字以下で指定してください。')
+                // ->dump()
         );
     }
-
 
     // category_idのバリデーションのテスト
     /** @test */
@@ -163,14 +136,14 @@ class StoreValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('ItemRequests/Create')
-            ->has('errors.category_id')
-            ->where('errors.category_id', '選択されたカテゴリは正しくありません。')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('ItemRequests/Create')
+                ->has('errors.category_id')
+                ->where('errors.category_id', '選択されたカテゴリは正しくありません。')
+                // ->dump()
         );
     }
-    
+
     /** @test */
     public function リクエスト新規登録バリデーションcategoryIdが最小の有効値()
     {
@@ -188,13 +161,13 @@ class StoreValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('ItemRequests/Create')
-            ->missing('errors.category_id')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('ItemRequests/Create')
+                ->missing('errors.category_id')
+                // ->dump()
         );
     }
-    
+
     /** @test */
     public function リクエスト新規登録バリデーションcategoryIdが最大の有効値()
     {
@@ -212,13 +185,13 @@ class StoreValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('ItemRequests/Create')
-            ->missing('errors.category_id')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('ItemRequests/Create')
+                ->missing('errors.category_id')
+                // ->dump()
         );
     }
-    
+
     /** @test */
     public function リクエスト新規登録バリデーションcategoryIdが最大値を超える無効値()
     {
@@ -236,14 +209,13 @@ class StoreValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('ItemRequests/Create')
-            ->has('errors.category_id')
-            ->where('errors.category_id', '選択されたカテゴリは正しくありません。')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('ItemRequests/Create')
+                ->has('errors.category_id')
+                ->where('errors.category_id', '選択されたカテゴリは正しくありません。')
+                // ->dump()
         );
     }
-
 
     // location_of_use_idのバリデーションのテスト
     /** @test */
@@ -263,11 +235,11 @@ class StoreValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('ItemRequests/Create')
-            ->has('errors.location_of_use_id')
-            ->where('errors.location_of_use_id', '選択された利用場所は正しくありません。')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('ItemRequests/Create')
+                ->has('errors.location_of_use_id')
+                ->where('errors.location_of_use_id', '選択された利用場所は正しくありません。')
+                // ->dump()
         );
     }
 
@@ -288,12 +260,12 @@ class StoreValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('ItemRequests/Create')
-            ->missing('errors.location_of_use_id')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('ItemRequests/Create')
+                ->missing('errors.location_of_use_id')
+                // ->dump()
         );
-    }    
+    }
 
     /** @test */
     public function リクエスト新規登録バリデーションlocation_of_use_idが最大の有効値()
@@ -312,12 +284,12 @@ class StoreValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('ItemRequests/Create')
-            ->missing('errors.location_of_use_id')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('ItemRequests/Create')
+                ->missing('errors.location_of_use_id')
+                // ->dump()
         );
-    }    
+    }
 
     /** @test */
     public function リクエスト新規登録バリデーションlocation_of_use_idが最大値を超える無効値()
@@ -336,15 +308,13 @@ class StoreValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('ItemRequests/Create')
-            ->has('errors.location_of_use_id')
-            ->where('errors.location_of_use_id', '選択された利用場所は正しくありません。')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('ItemRequests/Create')
+                ->has('errors.location_of_use_id')
+                ->where('errors.location_of_use_id', '選択された利用場所は正しくありません。')
+                // ->dump()
         );
     }
-
-
 
     // requestorのバリデーションテスト
     /** @test */
@@ -361,11 +331,11 @@ class StoreValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('ItemRequests/Create')
-            ->has('errors.requestor')
-            ->where('errors.requestor', '申請者は必ず指定してください。')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('ItemRequests/Create')
+                ->has('errors.requestor')
+                ->where('errors.requestor', '申請者は必ず指定してください。')
+                // ->dump()
         );
     }
 
@@ -383,10 +353,10 @@ class StoreValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('ItemRequests/Create')
-            ->missing('errors.requestor')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('ItemRequests/Create')
+                ->missing('errors.requestor')
+                // ->dump()
         );
     }
 
@@ -404,10 +374,10 @@ class StoreValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('ItemRequests/Create')
-            ->missing('errors.requestor')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('ItemRequests/Create')
+                ->missing('errors.requestor')
+                // ->dump()
         );
     }
 
@@ -425,14 +395,13 @@ class StoreValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('ItemRequests/Create')
-            ->has('errors.requestor')
-            ->where('errors.requestor', '申請者は、20文字以下で指定してください。')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('ItemRequests/Create')
+                ->has('errors.requestor')
+                ->where('errors.requestor', '申請者は、20文字以下で指定してください。')
+                // ->dump()
         );
     }
-
 
     // remarks_from_requestorのバリデーションのテスト
     /** @test */
@@ -449,11 +418,11 @@ class StoreValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('ItemRequests/Create')
-            ->has('errors.remarks_from_requestor')
-            ->where('errors.remarks_from_requestor', '申請理由は必ず指定してください。')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('ItemRequests/Create')
+                ->has('errors.remarks_from_requestor')
+                ->where('errors.remarks_from_requestor', '申請理由は必ず指定してください。')
+                // ->dump()
         );
     }
 
@@ -471,10 +440,10 @@ class StoreValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('ItemRequests/Create')
-            ->missing('errors.remarks_from_requestor')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('ItemRequests/Create')
+                ->missing('errors.remarks_from_requestor')
+                // ->dump()
         );
     }
 
@@ -492,10 +461,10 @@ class StoreValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('ItemRequests/Create')
-            ->missing('errors.remarks_from_requestor')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('ItemRequests/Create')
+                ->missing('errors.remarks_from_requestor')
+                // ->dump()
         );
     }
 
@@ -513,14 +482,13 @@ class StoreValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('ItemRequests/Create')
-            ->has('errors.remarks_from_requestor')
-            ->where('errors.remarks_from_requestor', '申請理由は、500文字以下で指定してください。')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('ItemRequests/Create')
+                ->has('errors.remarks_from_requestor')
+                ->where('errors.remarks_from_requestor', '申請理由は、500文字以下で指定してください。')
+                // ->dump()
         );
     }
-
 
     // manufacturerのバリデーションテスト
     /** @test */
@@ -537,10 +505,10 @@ class StoreValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('ItemRequests/Create')
-            ->missing('errors.manufacturer')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('ItemRequests/Create')
+                ->missing('errors.manufacturer')
+                // ->dump()
         );
     }
 
@@ -558,10 +526,10 @@ class StoreValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('ItemRequests/Create')
-            ->missing('errors.manufacturer')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('ItemRequests/Create')
+                ->missing('errors.manufacturer')
+                // ->dump()
         );
     }
 
@@ -579,10 +547,10 @@ class StoreValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('ItemRequests/Create')
-            ->missing('errors.manufacturer')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('ItemRequests/Create')
+                ->missing('errors.manufacturer')
+                // ->dump()
         );
     }
 
@@ -600,14 +568,13 @@ class StoreValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('ItemRequests/Create')
-            ->has('errors.manufacturer')
-            ->where('errors.manufacturer', 'メーカーは、20文字以下で指定してください。')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('ItemRequests/Create')
+                ->has('errors.manufacturer')
+                ->where('errors.manufacturer', 'メーカーは、20文字以下で指定してください。')
+                // ->dump()
         );
     }
-
 
     // referenceのバリデーションテスト
     /** @test */
@@ -624,10 +591,10 @@ class StoreValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('ItemRequests/Create')
-            ->missing('errors.reference')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('ItemRequests/Create')
+                ->missing('errors.reference')
+                // ->dump()
         );
     }
 
@@ -645,10 +612,10 @@ class StoreValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('ItemRequests/Create')
-            ->missing('errors.reference')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('ItemRequests/Create')
+                ->missing('errors.reference')
+                // ->dump()
         );
     }
 
@@ -666,10 +633,10 @@ class StoreValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('ItemRequests/Create')
-            ->missing('errors.reference')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('ItemRequests/Create')
+                ->missing('errors.reference')
+                // ->dump()
         );
     }
 
@@ -687,14 +654,13 @@ class StoreValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('ItemRequests/Create')
-            ->has('errors.reference')
-            ->where('errors.reference', '参考サイトは、20文字以下で指定してください。')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('ItemRequests/Create')
+                ->has('errors.reference')
+                ->where('errors.reference', '参考サイトは、20文字以下で指定してください。')
+                // ->dump()
         );
     }
-
 
     // priceのバリデーションテスト
     /** @test */
@@ -711,11 +677,11 @@ class StoreValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('ItemRequests/Create')
-            ->has('errors.price')
-            ->where('errors.price', '価格は整数で指定してください。')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('ItemRequests/Create')
+                ->has('errors.price')
+                ->where('errors.price', '価格は整数で指定してください。')
+                // ->dump()
         );
     }
 
@@ -733,10 +699,10 @@ class StoreValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->has('errors.price')
-            ->where('errors.price', '価格には、0以上の数字を指定してください。')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->has('errors.price')
+                ->where('errors.price', '価格には、0以上の数字を指定してください。')
+                // ->dump()
         );
     }
 
@@ -754,10 +720,10 @@ class StoreValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('ItemRequests/Create')
-            ->missing('errors.price')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('ItemRequests/Create')
+                ->missing('errors.price')
+                // ->dump()
         );
     }
 
@@ -775,10 +741,10 @@ class StoreValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('ItemRequests/Create')
-            ->missing('errors.price')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('ItemRequests/Create')
+                ->missing('errors.price')
+                // ->dump()
         );
     }
 
@@ -796,10 +762,10 @@ class StoreValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('ItemRequests/Create')
-            ->missing('errors.price')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('ItemRequests/Create')
+                ->missing('errors.price')
+                // ->dump()
         );
     }
 
@@ -817,15 +783,12 @@ class StoreValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('ItemRequests/Create')
-            ->has('errors.price')
-            ->where('errors.price', '価格には、1000000以下の数字を指定してください。')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('ItemRequests/Create')
+                ->has('errors.price')
+                ->where('errors.price', '価格には、1000000以下の数字を指定してください。')
+                // ->dump()
         );
     }
-
-
-
 
 }

--- a/tests/Feature/Http/Controllers/NotificationController/Index/IndexMethodTest.php
+++ b/tests/Feature/Http/Controllers/NotificationController/Index/IndexMethodTest.php
@@ -2,20 +2,19 @@
 
 namespace Tests\Feature\Http\Controllers\NotificationController\Index;
 
-use App\Models\Item;
 use App\Models\Disposal;
 use App\Models\Inspection;
+use App\Models\Item;
 use App\Models\ItemRequest;
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
-use Tests\TestCase;
-use Faker\Factory as FakerFactory;
 use App\Models\User;
-use App\Notifications\LowStockNotification;
 use App\Notifications\DisposalScheduleNotification;
 use App\Notifications\InspectionScheduleNotification;
+use App\Notifications\LowStockNotification;
 use App\Notifications\RequestedItemNotification;
+use Faker\Factory as FakerFactory;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Inertia\Testing\AssertableInertia as Assert;
+use Tests\TestCase;
 
 class IndexMethodTest extends TestCase
 {
@@ -30,29 +29,28 @@ class IndexMethodTest extends TestCase
 
     protected function tearDown(): void
     {
-        // 子クラスでのクリーンアップ処理
         parent::tearDown();
     }
 
     /** @test */
-    function NotificationControllerがデータを渡せる()
+    public function NotificationControllerがデータを渡せる()
     {
         $user = User::factory()->role(1)->create();
 
-        $item = Item::factory()->create();
+        $item       = Item::factory()->create();
         $inspection = Inspection::withoutEvents(function () {
             return Inspection::factory()->create();
         });
         $disposal = Disposal::withoutEvents(function () {
             return Disposal::factory()->create();
         });
-        
+
         $itemRequest = ItemRequest::factory()->create();
 
-        $lowStockNotification = new LowStockNotification($item);
-        $disposalScheduleNotification = new DisposalScheduleNotification($inspection);
+        $lowStockNotification           = new LowStockNotification($item);
+        $disposalScheduleNotification   = new DisposalScheduleNotification($inspection);
         $inspectionScheduleNotification = new InspectionScheduleNotification($disposal);
-        $requestedItemNotification = new RequestedItemNotification($itemRequest);
+        $requestedItemNotification      = new RequestedItemNotification($itemRequest);
 
         // 通知をデータベースに保存
         $user->notify($lowStockNotification);
@@ -65,12 +63,12 @@ class IndexMethodTest extends TestCase
         $response = $this->get('/notifications')
             ->assertOk();
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Notification')
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Notification')
                 ->has('notifications')
                 ->has('lowStockNotifications', 1)
                 ->has('inspectionAndDisposalNotifications', 2)
                 ->has('requestedItemNotifications', 1)
         );
-    }    
+    }
 }

--- a/tests/Feature/Http/Controllers/ProfileController/UpdateMethodTest.php
+++ b/tests/Feature/Http/Controllers/ProfileController/UpdateMethodTest.php
@@ -2,40 +2,13 @@
 
 namespace Tests\Feature\Http\Controllers\ProfileController;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
-use Tests\TestCase;
 use App\Models\User;
-use App\Models\Item;
-use App\Models\Unit;
-use App\Models\Category;
-use App\Models\Location;
-use App\Models\UsageStatus;
-use App\Models\AcquisitionMethod;
-use App\Models\Edithistory;
-use App\Models\Inspection;
-use App\Models\EditReason;
-use App\Models\RequestStatus;
-use App\Models\StockTransaction;
 use App\Services\ImageService;
 use Faker\Factory as FakerFactory;
-use Inertia\Testing\AssertableInertia as Assert;
-use Mockery;
-use App\Services\ManagementIdService;
-use Illuminate\Support\Facades\Auth;
-use Carbon\Carbon;
-use Illuminate\Database\Console\DumpCommand;
-use Illuminate\Testing\Fluent\AssertableJson;
-use Inertia\Inertia;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\UploadedFile;
-use Illuminate\Support\Facades\Storage;
-use Intervention\Image\ImageManager;
-// use Intervention\Image\Drivers\Gd\Driver;
-use Intervention\Image\Drivers\Imagick\Driver;
-use Illuminate\Support\Facades\Session;
-use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Log;
-
+use Mockery;
+use Tests\TestCase;
 
 class UpdateMethodTest extends TestCase
 {
@@ -49,7 +22,6 @@ class UpdateMethodTest extends TestCase
 
     protected function tearDown(): void
     {
-        // 子クラスでのクリーンアップ処理
         parent::tearDown();
     }
 
@@ -86,16 +58,16 @@ class UpdateMethodTest extends TestCase
 
         $response = $this->actingAs($user)
             ->patch('/profile', [
-                'name' => 'Test User',
-                'profile_image_file' => $this->fakeImage
+                'name'               => 'Test User',
+                'profile_image_file' => $this->fakeImage,
             ]);
 
         $response->assertSessionHasNoErrors()
             ->assertRedirect('/profile');
 
         $this->assertDatabaseHas('users', [
-            'name' => 'Test User',
-            'profile_image' => 'mocked_profile_image.jpg'
+            'name'          => 'Test User',
+            'profile_image' => 'mocked_profile_image.jpg',
         ]);
 
         $user->refresh();
@@ -149,9 +121,8 @@ class UpdateMethodTest extends TestCase
     //                 'profile_image_file' => $this->fakeImage
     //             ]);
 
-            
     //         // Mockeryのスパイを使ってメソッドが呼ばれたことを検証
-    //         // Mockery::spy(User::class)->shouldHaveReceived('save')->once();   
+    //         // Mockery::spy(User::class)->shouldHaveReceived('save')->once();
     //         // dd($response);
 
     //         $response->assertStatus(500);
@@ -162,20 +133,18 @@ class UpdateMethodTest extends TestCase
     //             // $response->assertSessionHasNoErrors()
     //             //     ->assertRedirect('/profile');
 
-
     //          // テストがここまで来るべきではないので失敗させる
     //         // $this->fail('Expected Exception not thrown.');
     //     } catch (\Exception $e) {
     //         // dd($e->getMessage());
     //         // 例外が発生したことを確認
     //         // $this->assertEquals('トランザクションの強制失敗', $e->getMessage());
-        
+
     //     }
 
     //     // フラッシュメッセージを確認
     //     // $response->assertSessionHas('message', 'プロフィールの更新中にエラーが発生しました');
     //     // $response->assertSessionHas('status', 'danger');
-
 
     //     // dd(session('errors'));
     //     // レスポンスの内容をダンプして確認
@@ -187,7 +156,7 @@ class UpdateMethodTest extends TestCase
     //     // プロフィール画像の削除が行われたかを確認
     //     Storage::disk()->assertMissing('profile/mocked_profile_image.jpg');
     //     Storage::disk()->assertExists('profile/before_profile_image.jpg');
-        
+
     //     $this->assertDatabaseHas('users', [
     //         'name' => 'BeforeTestUser',
     //         'profile_image' => 'before_profile_image.jpg'
@@ -240,7 +209,6 @@ class UpdateMethodTest extends TestCase
     //     $response->assertSessionHas('message', 'プロフィールの更新中にエラーが発生しました');
     //     $response->assertSessionHas('status', 'danger');
 
-
     //     // dd(session('errors'));
     //     // レスポンスの内容をダンプして確認
     //     // dd($response->getContent());
@@ -254,10 +222,6 @@ class UpdateMethodTest extends TestCase
     //     // $this->assertSame('Test User', $user->name);
     //     // $this->assertSame('mocked_profile_image.jpg', $user->profile_image);
     // }
-
-
-
-
 
     // デフォルトで用意されていたテスト
     // public function test_email_verification_status_is_unchanged_when_the_email_address_is_unchanged(): void

--- a/tests/Feature/Http/Controllers/ProfileController/UpdateValidationTest.php
+++ b/tests/Feature/Http/Controllers/ProfileController/UpdateValidationTest.php
@@ -2,38 +2,11 @@
 
 namespace Tests\Feature\Http\Controllers\ProfileController;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
-use Tests\TestCase;
 use App\Models\User;
-use App\Models\Item;
-use App\Models\Unit;
-use App\Models\Category;
-use App\Models\Location;
-use App\Models\UsageStatus;
-use App\Models\AcquisitionMethod;
-use App\Models\Edithistory;
-use App\Models\Inspection;
-use App\Models\EditReason;
-use App\Models\RequestStatus;
-use App\Models\StockTransaction;
-use App\Services\ImageService;
 use Faker\Factory as FakerFactory;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Inertia\Testing\AssertableInertia as Assert;
-use Mockery;
-use App\Services\ManagementIdService;
-use Illuminate\Support\Facades\Auth;
-use Carbon\Carbon;
-use Illuminate\Database\Console\DumpCommand;
-use Illuminate\Testing\Fluent\AssertableJson;
-use Inertia\Inertia;
-use Illuminate\Http\UploadedFile;
-use Illuminate\Support\Facades\Storage;
-use Intervention\Image\ImageManager;
-// use Intervention\Image\Drivers\Gd\Driver;
-use Intervention\Image\Drivers\Imagick\Driver;
-use Illuminate\Support\Facades\Session;
-use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Tests\TestCase;
 
 class UpdateValidationTest extends TestCase
 {
@@ -48,7 +21,6 @@ class UpdateValidationTest extends TestCase
 
     protected function tearDown(): void
     {
-        // 子クラスでのクリーンアップ処理
         parent::tearDown();
     }
 
@@ -59,7 +31,6 @@ class UpdateValidationTest extends TestCase
         $user = User::factory()->role(1)->create();
         $this->actingAs($user);
 
-
         $response = $this->from('profile')
             ->patch(route('profile.update'), ['name' => '']);
         $response->assertRedirect('profile'); //URLにリダイレクト
@@ -67,11 +38,11 @@ class UpdateValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Profile/Edit')
-            ->has('errors.name')
-            ->where('errors.name', '名前は必ず指定してください。')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Profile/Edit')
+                ->has('errors.name')
+                ->where('errors.name', '名前は必ず指定してください。')
+                // ->dump()
         );
     }
 
@@ -81,7 +52,6 @@ class UpdateValidationTest extends TestCase
         $user = User::factory()->role(1)->create();
         $this->actingAs($user);
 
-
         $response = $this->from('profile')
             ->patch(route('profile.update'), ['name' => str_repeat('あ', 20)]);
         $response->assertRedirect('profile'); //URLにリダイレクト
@@ -89,10 +59,10 @@ class UpdateValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Profile/Edit')
-            ->missing('errors.name')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Profile/Edit')
+                ->missing('errors.name')
+                // ->dump()
         );
     }
 
@@ -102,7 +72,6 @@ class UpdateValidationTest extends TestCase
         $user = User::factory()->role(1)->create();
         $this->actingAs($user);
 
-
         $response = $this->from('profile')
             ->patch(route('profile.update'), ['name' => str_repeat('あ', 21)]);
         $response->assertRedirect('profile'); //URLにリダイレクト
@@ -110,11 +79,11 @@ class UpdateValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('Profile/Edit')
-            ->has('errors.name')
-            ->where('errors.name', '名前は、20文字以下で指定してください。')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('Profile/Edit')
+                ->has('errors.name')
+                ->where('errors.name', '名前は、20文字以下で指定してください。')
+                // ->dump()
         );
     }
 }

--- a/tests/Feature/Http/Controllers/UpdateStockController/decreaseStock/decreaseStockMethodTest.php
+++ b/tests/Feature/Http/Controllers/UpdateStockController/decreaseStock/decreaseStockMethodTest.php
@@ -2,38 +2,13 @@
 
 namespace Tests\Feature\Http\Controllers\UpdateStockController\decreaseStock;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
-use Tests\TestCase;
-use App\Models\User;
-use App\Models\Item;
-use App\Models\Unit;
 use App\Models\Category;
-use App\Models\Location;
-use App\Models\UsageStatus;
-use App\Models\AcquisitionMethod;
-use App\Models\Edithistory;
-use App\Models\Inspection;
-use App\Models\EditReason;
-use App\Models\RequestStatus;
-use App\Models\StockTransaction;
-use App\Services\ImageService;
+use App\Models\Item;
+use App\Models\User;
 use Faker\Factory as FakerFactory;
-use Inertia\Testing\AssertableInertia as Assert;
-use Mockery;
-use App\Services\ManagementIdService;
-use Illuminate\Support\Facades\Auth;
-use Carbon\Carbon;
-use Illuminate\Database\Console\DumpCommand;
-use Illuminate\Testing\Fluent\AssertableJson;
-use Inertia\Inertia;
-use Illuminate\Http\UploadedFile;
-use Illuminate\Support\Facades\Storage;
-use Intervention\Image\ImageManager;
-// use Intervention\Image\Drivers\Gd\Driver;
-use Intervention\Image\Drivers\Imagick\Driver;
-use Illuminate\Support\Facades\Session;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
 
 class decreaseStockMethodTest extends TestCase
 {
@@ -48,14 +23,12 @@ class decreaseStockMethodTest extends TestCase
 
     protected function tearDown(): void
     {
-        // 子クラスでのクリーンアップ処理
         parent::tearDown();
     }
 
     // 在庫数以下にはquantityを出来ないバリデーションRulesがStockLimit
-  
     /** @test */
-    function 出庫モーダルで出庫処理が出来る()
+    public function 出庫モーダルで出庫処理が出来る()
     {
         // categoriesテーブルをトランケートして連番をリセット
         DB::statement('SET FOREIGN_KEY_CHECKS=0;');
@@ -70,36 +43,32 @@ class decreaseStockMethodTest extends TestCase
 
         // テスト用の備品を作成、消耗品(category_id=1)のみ入出庫できる
         $item = Item::factory()->create([
-            'category_id' => $category->id,
-            'stock' => 10,
-            'minimum_stock' => 2
+            'category_id'   => $category->id,
+            'stock'         => 10,
+            'minimum_stock' => 2,
         ]);
 
         $validData = [
-            'item_id' => $item->id,
+            'item_id'          => $item->id,
             'transaction_type' => '出庫',
-            'operator_name' => $user->name,
-            'quantity' => 3,
+            'operator_name'    => $user->name,
+            'quantity'         => 3,
         ];
-
-        \Log::info('CSRFトークン（リクエストヘッダー）: ' . csrf_token());
-        \Log::info('CSRFトークン（セッション）: ' . session()->token());
-        // dd(csrf_token(), session()->token());
 
         // 備品を出庫処理
         $response = $this->put(route('decreaseStock', $item->id), $validData);
         $response->assertStatus(302); // リダイレクトを確認
 
         $this->assertDatabaseHas('items', [
-            'id' => $item->id,
-            'stock' => '7'
+            'id'    => $item->id,
+            'stock' => '7',
         ]);
 
         $this->assertDatabaseHas('stock_transactions', [
-            'item_id' => $item->id,
+            'item_id'          => $item->id,
             'transaction_type' => '出庫',
-            'operator_name' => $user->name,
-            'quantity' => -3, //出庫はマイナスの数値で保存する
+            'operator_name'    => $user->name,
+            'quantity'         => -3, //出庫はマイナスの数値で保存する
         ]);
     }
 }

--- a/tests/Feature/Http/Controllers/UpdateStockController/decreaseStock/decreaseStockValidationTest.php
+++ b/tests/Feature/Http/Controllers/UpdateStockController/decreaseStock/decreaseStockValidationTest.php
@@ -2,38 +2,14 @@
 
 namespace Tests\Feature\Http\Controllers\UpdateStockController\decreaseStock;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
-use Tests\TestCase;
-use App\Models\User;
-use App\Models\Item;
-use App\Models\Unit;
 use App\Models\Category;
-use App\Models\Location;
-use App\Models\UsageStatus;
-use App\Models\AcquisitionMethod;
-use App\Models\Edithistory;
-use App\Models\Inspection;
-use App\Models\EditReason;
-use App\Models\RequestStatus;
-use App\Models\StockTransaction;
-use App\Services\ImageService;
+use App\Models\Item;
+use App\Models\User;
 use Faker\Factory as FakerFactory;
-use Inertia\Testing\AssertableInertia as Assert;
-use Mockery;
-use App\Services\ManagementIdService;
-use Illuminate\Support\Facades\Auth;
-use Carbon\Carbon;
-use Illuminate\Database\Console\DumpCommand;
-use Illuminate\Testing\Fluent\AssertableJson;
-use Inertia\Inertia;
-use Illuminate\Http\UploadedFile;
-use Illuminate\Support\Facades\Storage;
-use Intervention\Image\ImageManager;
-// use Intervention\Image\Drivers\Gd\Driver;
-use Intervention\Image\Drivers\Imagick\Driver;
-use Illuminate\Support\Facades\Session;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
+use Inertia\Testing\AssertableInertia as Assert;
+use Tests\TestCase;
 
 class decreaseStockValidationTest extends TestCase
 {
@@ -48,19 +24,18 @@ class decreaseStockValidationTest extends TestCase
 
     protected function tearDown(): void
     {
-        // 子クラスでのクリーンアップ処理
         parent::tearDown();
     }
 
     // DecreaseStockRequestのバリデーションのテスト
     // 在庫数以下にはquantityを出来ないバリデーションRulesがStockLimit
     /** @test */
-    function 入出庫モーダルでの出庫処理バリデーションoperator_nameがnullで無効値な場合()
+    public function 入出庫モーダルでの出庫処理バリデーションoperator_nameがnullで無効値な場合()
     {
         // categoriesテーブルをトランケートして連番をリセット
         DB::statement('SET FOREIGN_KEY_CHECKS=0;');
         DB::table('categories')->truncate();
-        DB::statement('SET FOREIGN_KEY_CHECKS=1;');        
+        DB::statement('SET FOREIGN_KEY_CHECKS=1;');
 
         // 世界を構築
         $category = Category::factory()->create(['id' => 1]);
@@ -70,7 +45,7 @@ class decreaseStockValidationTest extends TestCase
 
         // テスト用の備品を作成、消耗品(category_id=1)のみ入出庫できる
         $item = Item::factory()->create([
-            'category_id' => $category->id
+            'category_id' => $category->id,
         ]);
 
         $response = $this->from('consumable_items')
@@ -80,16 +55,16 @@ class decreaseStockValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('ConsumableItems/Index')
-            ->has('errors.operator_name')
-            ->where('errors.operator_name', '実施者は必ず指定してください。')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('ConsumableItems/Index')
+                ->has('errors.operator_name')
+                ->where('errors.operator_name', '実施者は必ず指定してください。')
+                // ->dump()
         );
     }
 
     /** @test */
-    function 入出庫モーダルでの出庫処理バリデーションoperator_nameが1文字で有効値な場合()
+    public function 入出庫モーダルでの出庫処理バリデーションoperator_nameが1文字で有効値な場合()
     {
         // categoriesテーブルをトランケートして連番をリセット
         DB::statement('SET FOREIGN_KEY_CHECKS=0;');
@@ -104,7 +79,7 @@ class decreaseStockValidationTest extends TestCase
 
         // テスト用の備品を作成、消耗品(category_id=1)のみ入出庫できる
         $item = Item::factory()->create([
-            'category_id' => $category->id
+            'category_id' => $category->id,
         ]);
 
         $response = $this->from('consumable_items')
@@ -114,21 +89,21 @@ class decreaseStockValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('ConsumableItems/Index')
-            ->missing('errors.operator_name')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('ConsumableItems/Index')
+                ->missing('errors.operator_name')
+                // ->dump()
         );
     }
 
     /** @test */
-    function 入出庫モーダルでの出庫処理バリデーションoperator_nameが10文字で有効境界値な場合()
+    public function 入出庫モーダルでの出庫処理バリデーションoperator_nameが10文字で有効境界値な場合()
     {
         // categoriesテーブルをトランケートして連番をリセット
         DB::statement('SET FOREIGN_KEY_CHECKS=0;');
         DB::table('categories')->truncate();
         DB::statement('SET FOREIGN_KEY_CHECKS=1;');
-        
+
         // 世界を構築
         $category = Category::factory()->create(['id' => 1]);
 
@@ -137,7 +112,7 @@ class decreaseStockValidationTest extends TestCase
 
         // テスト用の備品を作成、消耗品(category_id=1)のみ入出庫できる
         $item = Item::factory()->create([
-            'category_id' => $category->id
+            'category_id' => $category->id,
         ]);
 
         $response = $this->from('consumable_items')
@@ -147,21 +122,21 @@ class decreaseStockValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('ConsumableItems/Index')
-            ->missing('errors.operator_name')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('ConsumableItems/Index')
+                ->missing('errors.operator_name')
+                // ->dump()
         );
     }
 
     /** @test */
-    function 入出庫モーダルでの出庫処理バリデーションoperator_nameが11文字で無効境界値な場合()
+    public function 入出庫モーダルでの出庫処理バリデーションoperator_nameが11文字で無効境界値な場合()
     {
         // categoriesテーブルをトランケートして連番をリセット
         DB::statement('SET FOREIGN_KEY_CHECKS=0;');
         DB::table('categories')->truncate();
         DB::statement('SET FOREIGN_KEY_CHECKS=1;');
-        
+
         // 世界を構築
         $category = Category::factory()->create(['id' => 1]);
 
@@ -170,7 +145,7 @@ class decreaseStockValidationTest extends TestCase
 
         // テスト用の備品を作成、消耗品(category_id=1)のみ入出庫できる
         $item = Item::factory()->create([
-            'category_id' => $category->id
+            'category_id' => $category->id,
         ]);
 
         $response = $this->from('consumable_items')
@@ -180,23 +155,22 @@ class decreaseStockValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('ConsumableItems/Index')
-            ->has('errors.operator_name')
-            ->where('errors.operator_name', '実施者は、10文字以下で指定してください。')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('ConsumableItems/Index')
+                ->has('errors.operator_name')
+                ->where('errors.operator_name', '実施者は、10文字以下で指定してください。')
+                // ->dump()
         );
     }
 
-
     /** @test */
-    function 入出庫モーダルでの出庫処理バリデーションquantityがnullで無効値な場合()
+    public function 入出庫モーダルでの出庫処理バリデーションquantityがnullで無効値な場合()
     {
         // categoriesテーブルをトランケートして連番をリセット
         DB::statement('SET FOREIGN_KEY_CHECKS=0;');
         DB::table('categories')->truncate();
         DB::statement('SET FOREIGN_KEY_CHECKS=1;');
-        
+
         // 世界を構築
         $category = Category::factory()->create(['id' => 1]);
 
@@ -205,9 +179,9 @@ class decreaseStockValidationTest extends TestCase
 
         // テスト用の備品を作成、消耗品(category_id=1)のみ入出庫できる
         $item = Item::factory()->create([
-            'category_id' => $category->id,
-            'stock' => 10,
-            'minimum_stock' => 2
+            'category_id'   => $category->id,
+            'stock'         => 10,
+            'minimum_stock' => 2,
         ]);
 
         $response = $this->from('consumable_items')
@@ -217,22 +191,22 @@ class decreaseStockValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('ConsumableItems/Index')
-            ->has('errors.quantity')
-            ->where('errors.quantity', '数量は必ず指定してください。')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('ConsumableItems/Index')
+                ->has('errors.quantity')
+                ->where('errors.quantity', '数量は必ず指定してください。')
+                // ->dump()
         );
     }
 
     /** @test */
-    function 入出庫モーダルでの出庫処理バリデーションquantityが0で無効境界値な場合()
+    public function 入出庫モーダルでの出庫処理バリデーションquantityが0で無効境界値な場合()
     {
         // categoriesテーブルをトランケートして連番をリセット
         DB::statement('SET FOREIGN_KEY_CHECKS=0;');
         DB::table('categories')->truncate();
         DB::statement('SET FOREIGN_KEY_CHECKS=1;');
-        
+
         // 世界を構築
         $category = Category::factory()->create(['id' => 1]);
 
@@ -241,9 +215,9 @@ class decreaseStockValidationTest extends TestCase
 
         // テスト用の備品を作成、消耗品(category_id=1)のみ入出庫できる
         $item = Item::factory()->create([
-            'category_id' => $category->id,
-            'stock' => 10,
-            'minimum_stock' => 2
+            'category_id'   => $category->id,
+            'stock'         => 10,
+            'minimum_stock' => 2,
         ]);
 
         $response = $this->from('consumable_items')
@@ -253,22 +227,22 @@ class decreaseStockValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('ConsumableItems/Index')
-            ->has('errors.quantity')
-            ->where('errors.quantity', '数量には、1以上の数字を指定してください。')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('ConsumableItems/Index')
+                ->has('errors.quantity')
+                ->where('errors.quantity', '数量には、1以上の数字を指定してください。')
+                // ->dump()
         );
     }
 
     /** @test */
-    function 入出庫モーダルでの出庫処理バリデーションquantityが1で有効境界値な場合()
+    public function 入出庫モーダルでの出庫処理バリデーションquantityが1で有効境界値な場合()
     {
         // categoriesテーブルをトランケートして連番をリセット
         DB::statement('SET FOREIGN_KEY_CHECKS=0;');
         DB::table('categories')->truncate();
         DB::statement('SET FOREIGN_KEY_CHECKS=1;');
-        
+
         // 世界を構築
         $category = Category::factory()->create(['id' => 1]);
 
@@ -277,9 +251,9 @@ class decreaseStockValidationTest extends TestCase
 
         // テスト用の備品を作成、消耗品(category_id=1)のみ入出庫できる
         $item = Item::factory()->create([
-            'category_id' => $category->id,
-            'stock' => 10,
-            'minimum_stock' => 2
+            'category_id'   => $category->id,
+            'stock'         => 10,
+            'minimum_stock' => 2,
         ]);
 
         $response = $this->from('consumable_items')
@@ -289,15 +263,15 @@ class decreaseStockValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('ConsumableItems/Index')
-            ->missing('errors.quantity')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('ConsumableItems/Index')
+                ->missing('errors.quantity')
+                // ->dump()
         );
     }
 
     /** @test */
-    function 入出庫モーダルでの出庫処理バリデーションquantity上限が在庫数で有効境界値な場合()
+    public function 入出庫モーダルでの出庫処理バリデーションquantity上限が在庫数で有効境界値な場合()
     {
         // categoriesテーブルをトランケートして連番をリセット
         DB::statement('SET FOREIGN_KEY_CHECKS=0;');
@@ -312,9 +286,9 @@ class decreaseStockValidationTest extends TestCase
 
         // テスト用の備品を作成、消耗品(category_id=1)のみ入出庫できる
         $item = Item::factory()->create([
-            'category_id' => $category->id,
-            'stock' => 10,
-            'minimum_stock' => 2
+            'category_id'   => $category->id,
+            'stock'         => 10,
+            'minimum_stock' => 2,
         ]);
 
         $response = $this->from('consumable_items')
@@ -324,15 +298,15 @@ class decreaseStockValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('ConsumableItems/Index')
-            ->missing('errors.quantity')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('ConsumableItems/Index')
+                ->missing('errors.quantity')
+                // ->dump()
         );
     }
 
     /** @test */
-    function 入出庫モーダルでの出庫処理バリデーションquantity上限が在庫数で無効境界値な場合()
+    public function 入出庫モーダルでの出庫処理バリデーションquantity上限が在庫数で無効境界値な場合()
     {
         // categoriesテーブルをトランケートして連番をリセット
         DB::statement('SET FOREIGN_KEY_CHECKS=0;');
@@ -347,9 +321,9 @@ class decreaseStockValidationTest extends TestCase
 
         // テスト用の備品を作成、消耗品(category_id=1)のみ入出庫できる
         $item = Item::factory()->create([
-            'category_id' => $category->id,
-            'stock' => 10,
-            'minimum_stock' => 2
+            'category_id'   => $category->id,
+            'stock'         => 10,
+            'minimum_stock' => 2,
         ]);
 
         $response = $this->from('consumable_items')
@@ -359,11 +333,11 @@ class decreaseStockValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('ConsumableItems/Index')
-            ->has('errors.quantity')
-            ->where('errors.quantity', '在庫数以上の数量は出庫できません')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('ConsumableItems/Index')
+                ->has('errors.quantity')
+                ->where('errors.quantity', '在庫数以上の数量は出庫できません')
+                // ->dump()
         );
     }
 }

--- a/tests/Feature/Http/Controllers/UpdateStockController/increaseStock/increaseStockMethodTest.php
+++ b/tests/Feature/Http/Controllers/UpdateStockController/increaseStock/increaseStockMethodTest.php
@@ -2,38 +2,13 @@
 
 namespace Tests\Feature\Http\Controllers\UpdateStockController\increaseStock;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
-use Tests\TestCase;
-use App\Models\User;
-use App\Models\Item;
-use App\Models\Unit;
 use App\Models\Category;
-use App\Models\Location;
-use App\Models\UsageStatus;
-use App\Models\AcquisitionMethod;
-use App\Models\Edithistory;
-use App\Models\Inspection;
-use App\Models\EditReason;
-use App\Models\RequestStatus;
-use App\Models\StockTransaction;
-use App\Services\ImageService;
+use App\Models\Item;
+use App\Models\User;
 use Faker\Factory as FakerFactory;
-use Inertia\Testing\AssertableInertia as Assert;
-use Mockery;
-use App\Services\ManagementIdService;
-use Illuminate\Support\Facades\Auth;
-use Carbon\Carbon;
-use Illuminate\Database\Console\DumpCommand;
-use Illuminate\Testing\Fluent\AssertableJson;
-use Inertia\Inertia;
-use Illuminate\Http\UploadedFile;
-use Illuminate\Support\Facades\Storage;
-use Intervention\Image\ImageManager;
-// use Intervention\Image\Drivers\Gd\Driver;
-use Intervention\Image\Drivers\Imagick\Driver;
-use Illuminate\Support\Facades\Session;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
 
 class increaseStockMethodTest extends TestCase
 {
@@ -48,12 +23,11 @@ class increaseStockMethodTest extends TestCase
 
     protected function tearDown(): void
     {
-        // 子クラスでのクリーンアップ処理
         parent::tearDown();
     }
 
     /** @test */
-    function 入庫モーダルで入庫処理が出来る()
+    public function 入庫モーダルで入庫処理が出来る()
     {
         // categoriesテーブルをトランケートして連番をリセット
         DB::statement('SET FOREIGN_KEY_CHECKS=0;');
@@ -68,16 +42,16 @@ class increaseStockMethodTest extends TestCase
 
         // テスト用の備品を作成、消耗品(category_id=1)のみ入出庫できる
         $item = Item::factory()->create([
-            'category_id' => $category->id,
-            'stock' => 10,
-            'minimum_stock' => 2
+            'category_id'   => $category->id,
+            'stock'         => 10,
+            'minimum_stock' => 2,
         ]);
 
         $validData = [
-            'item_id' => $item->id,
+            'item_id'          => $item->id,
             'transaction_type' => '入庫',
-            'operator_name' => $user->name,
-            'quantity' => 3,
+            'operator_name'    => $user->name,
+            'quantity'         => 3,
         ];
 
         // 備品を入庫処理
@@ -86,15 +60,15 @@ class increaseStockMethodTest extends TestCase
         $response->assertStatus(302); // リダイレクトを確認
 
         $this->assertDatabaseHas('items', [
-            'id' => $item->id,
-            'stock' => '13'
+            'id'    => $item->id,
+            'stock' => '13',
         ]);
 
         $this->assertDatabaseHas('stock_transactions', [
-            'item_id' => $item->id,
+            'item_id'          => $item->id,
             'transaction_type' => '入庫',
-            'operator_name' => $user->name,
-            'quantity' => 3,
+            'operator_name'    => $user->name,
+            'quantity'         => 3,
         ]);
     }
 }

--- a/tests/Feature/Http/Controllers/UpdateStockController/increaseStock/increaseStockValidationTest.php
+++ b/tests/Feature/Http/Controllers/UpdateStockController/increaseStock/increaseStockValidationTest.php
@@ -2,38 +2,14 @@
 
 namespace Tests\Feature\Http\Controllers\UpdateStockController\increaseStock;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
-use Tests\TestCase;
-use App\Models\User;
-use App\Models\Item;
-use App\Models\Unit;
 use App\Models\Category;
-use App\Models\Location;
-use App\Models\UsageStatus;
-use App\Models\AcquisitionMethod;
-use App\Models\Edithistory;
-use App\Models\Inspection;
-use App\Models\EditReason;
-use App\Models\RequestStatus;
-use App\Models\StockTransaction;
-use App\Services\ImageService;
+use App\Models\Item;
+use App\Models\User;
 use Faker\Factory as FakerFactory;
-use Inertia\Testing\AssertableInertia as Assert;
-use Mockery;
-use App\Services\ManagementIdService;
-use Illuminate\Support\Facades\Auth;
-use Carbon\Carbon;
-use Illuminate\Database\Console\DumpCommand;
-use Illuminate\Testing\Fluent\AssertableJson;
-use Inertia\Inertia;
-use Illuminate\Http\UploadedFile;
-use Illuminate\Support\Facades\Storage;
-use Intervention\Image\ImageManager;
-// use Intervention\Image\Drivers\Gd\Driver;
-use Intervention\Image\Drivers\Imagick\Driver;
-use Illuminate\Support\Facades\Session;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
+use Inertia\Testing\AssertableInertia as Assert;
+use Tests\TestCase;
 
 class increaseStockValidationTest extends TestCase
 {
@@ -48,13 +24,12 @@ class increaseStockValidationTest extends TestCase
 
     protected function tearDown(): void
     {
-        // 子クラスでのクリーンアップ処理
         parent::tearDown();
     }
 
     //　IncreaseStockRequestのバリデーションのテスト
     /** @test */
-    function 入出庫モーダルでの入庫処理バリデーションoperator_nameがnullで無効値な場合()
+    public function 入出庫モーダルでの入庫処理バリデーションoperator_nameがnullで無効値な場合()
     {
         // categoriesテーブルをトランケートして連番をリセット
         DB::statement('SET FOREIGN_KEY_CHECKS=0;');
@@ -69,7 +44,7 @@ class increaseStockValidationTest extends TestCase
 
         // テスト用の備品を作成、消耗品(category_id=1)のみ入出庫できる
         $item = Item::factory()->create([
-            'category_id' => $category->id
+            'category_id' => $category->id,
         ]);
 
         $response = $this->from('consumable_items')
@@ -79,16 +54,16 @@ class increaseStockValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('ConsumableItems/Index')
-            ->has('errors.operator_name')
-            ->where('errors.operator_name', '実施者は必ず指定してください。')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('ConsumableItems/Index')
+                ->has('errors.operator_name')
+                ->where('errors.operator_name', '実施者は必ず指定してください。')
+                // ->dump()
         );
     }
 
     /** @test */
-    function 入出庫モーダルでの入庫処理バリデーションoperator_nameが1文字で有効値な場合()
+    public function 入出庫モーダルでの入庫処理バリデーションoperator_nameが1文字で有効値な場合()
     {
         // categoriesテーブルをトランケートして連番をリセット
         DB::statement('SET FOREIGN_KEY_CHECKS=0;');
@@ -103,7 +78,7 @@ class increaseStockValidationTest extends TestCase
 
         // テスト用の備品を作成、消耗品(category_id=1)のみ入出庫できる
         $item = Item::factory()->create([
-            'category_id' => $category->id
+            'category_id' => $category->id,
         ]);
 
         $response = $this->from('consumable_items')
@@ -113,21 +88,21 @@ class increaseStockValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('ConsumableItems/Index')
-            ->missing('errors.operator_name')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('ConsumableItems/Index')
+                ->missing('errors.operator_name')
+                // ->dump()
         );
     }
 
     /** @test */
-    function 入出庫モーダルでの入庫処理バリデーションoperator_nameが10文字で有効境界値な場合()
+    public function 入出庫モーダルでの入庫処理バリデーションoperator_nameが10文字で有効境界値な場合()
     {
         // categoriesテーブルをトランケートして連番をリセット
         DB::statement('SET FOREIGN_KEY_CHECKS=0;');
         DB::table('categories')->truncate();
         DB::statement('SET FOREIGN_KEY_CHECKS=1;');
-        
+
         // 世界を構築
         $category = Category::factory()->create(['id' => 1]);
 
@@ -136,7 +111,7 @@ class increaseStockValidationTest extends TestCase
 
         // テスト用の備品を作成、消耗品(category_id=1)のみ入出庫できる
         $item = Item::factory()->create([
-            'category_id' => $category->id
+            'category_id' => $category->id,
         ]);
 
         $response = $this->from('consumable_items')
@@ -146,15 +121,15 @@ class increaseStockValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('ConsumableItems/Index')
-            ->missing('errors.operator_name')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('ConsumableItems/Index')
+                ->missing('errors.operator_name')
+                // ->dump()
         );
     }
 
     /** @test */
-    function 入出庫モーダルでの入庫処理バリデーションoperator_nameが11文字で無効境界値な場合()
+    public function 入出庫モーダルでの入庫処理バリデーションoperator_nameが11文字で無効境界値な場合()
     {
         // categoriesテーブルをトランケートして連番をリセット
         DB::statement('SET FOREIGN_KEY_CHECKS=0;');
@@ -169,7 +144,7 @@ class increaseStockValidationTest extends TestCase
 
         // テスト用の備品を作成、消耗品(category_id=1)のみ入出庫できる
         $item = Item::factory()->create([
-            'category_id' => $category->id
+            'category_id' => $category->id,
         ]);
 
         $response = $this->from('consumable_items')
@@ -179,22 +154,22 @@ class increaseStockValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('ConsumableItems/Index')
-            ->has('errors.operator_name')
-            ->where('errors.operator_name', '実施者は、10文字以下で指定してください。')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('ConsumableItems/Index')
+                ->has('errors.operator_name')
+                ->where('errors.operator_name', '実施者は、10文字以下で指定してください。')
+                // ->dump()
         );
     }
 
     /** @test */
-    function 入出庫モーダルでの入庫処理バリデーションquantityがnullで無効値な場合()
+    public function 入出庫モーダルでの入庫処理バリデーションquantityがnullで無効値な場合()
     {
         // categoriesテーブルをトランケートして連番をリセット
         DB::statement('SET FOREIGN_KEY_CHECKS=0;');
         DB::table('categories')->truncate();
         DB::statement('SET FOREIGN_KEY_CHECKS=1;');
-        
+
         // 世界を構築
         $category = Category::factory()->create(['id' => 1]);
 
@@ -213,16 +188,16 @@ class increaseStockValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('ConsumableItems/Index')
-            ->has('errors.quantity')
-            ->where('errors.quantity', '数量は必ず指定してください。')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('ConsumableItems/Index')
+                ->has('errors.quantity')
+                ->where('errors.quantity', '数量は必ず指定してください。')
+                // ->dump()
         );
     }
 
     /** @test */
-    function 入出庫モーダルでの入庫処理バリデーションquantityが0で無効境界値な場合()
+    public function 入出庫モーダルでの入庫処理バリデーションquantityが0で無効境界値な場合()
     {
         // categoriesテーブルをトランケートして連番をリセット
         DB::statement('SET FOREIGN_KEY_CHECKS=0;');
@@ -237,7 +212,7 @@ class increaseStockValidationTest extends TestCase
 
         // テスト用の備品を作成、消耗品(category_id=1)のみ入出庫できる
         $item = Item::factory()->create([
-            'category_id' => $category->id
+            'category_id' => $category->id,
         ]);
 
         $response = $this->from('consumable_items')
@@ -247,22 +222,22 @@ class increaseStockValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('ConsumableItems/Index')
-            ->has('errors.quantity')
-            ->where('errors.quantity', '数量には、1以上の数字を指定してください。')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('ConsumableItems/Index')
+                ->has('errors.quantity')
+                ->where('errors.quantity', '数量には、1以上の数字を指定してください。')
+                // ->dump()
         );
     }
 
     /** @test */
-    function 入出庫モーダルでの入庫処理バリデーションquantityが1で有効境界値な場合()
+    public function 入出庫モーダルでの入庫処理バリデーションquantityが1で有効境界値な場合()
     {
         // categoriesテーブルをトランケートして連番をリセット
         DB::statement('SET FOREIGN_KEY_CHECKS=0;');
         DB::table('categories')->truncate();
         DB::statement('SET FOREIGN_KEY_CHECKS=1;');
-        
+
         // 世界を構築
         $category = Category::factory()->create(['id' => 1]);
 
@@ -271,7 +246,7 @@ class increaseStockValidationTest extends TestCase
 
         // テスト用の備品を作成、消耗品(category_id=1)のみ入出庫できる
         $item = Item::factory()->create([
-            'category_id' => $category->id
+            'category_id' => $category->id,
         ]);
 
         $response = $this->from('consumable_items')
@@ -281,21 +256,21 @@ class increaseStockValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('ConsumableItems/Index')
-            ->missing('errors.quantity')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('ConsumableItems/Index')
+                ->missing('errors.quantity')
+                // ->dump()
         );
     }
 
     /** @test */
-    function 入出庫モーダルでの入庫処理バリデーションquantityが500で有効境界値な場合()
+    public function 入出庫モーダルでの入庫処理バリデーションquantityが500で有効境界値な場合()
     {
         // categoriesテーブルをトランケートして連番をリセット
         DB::statement('SET FOREIGN_KEY_CHECKS=0;');
         DB::table('categories')->truncate();
         DB::statement('SET FOREIGN_KEY_CHECKS=1;');
-    
+
         // 世界を構築
         $category = Category::factory()->create(['id' => 1]);
 
@@ -304,7 +279,7 @@ class increaseStockValidationTest extends TestCase
 
         // テスト用の備品を作成、消耗品(category_id=1)のみ入出庫できる
         $item = Item::factory()->create([
-            'category_id' => $category->id
+            'category_id' => $category->id,
         ]);
 
         $response = $this->from('consumable_items')
@@ -314,15 +289,15 @@ class increaseStockValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('ConsumableItems/Index')
-            ->missing('errors.quantity')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('ConsumableItems/Index')
+                ->missing('errors.quantity')
+                // ->dump()
         );
     }
 
     /** @test */
-    function 入出庫モーダルでの入庫処理バリデーションquantityが501で無効境界値な場合()
+    public function 入出庫モーダルでの入庫処理バリデーションquantityが501で無効境界値な場合()
     {
         // categoriesテーブルをトランケートして連番をリセット
         DB::statement('SET FOREIGN_KEY_CHECKS=0;');
@@ -337,7 +312,7 @@ class increaseStockValidationTest extends TestCase
 
         // テスト用の備品を作成、消耗品(category_id=1)のみ入出庫できる
         $item = Item::factory()->create([
-            'category_id' => $category->id
+            'category_id' => $category->id,
         ]);
 
         $response = $this->from('consumable_items')
@@ -347,11 +322,11 @@ class increaseStockValidationTest extends TestCase
 
         $response = $this->followRedirects($response);
 
-        $response->assertInertia(fn (Assert $page) => $page
-            ->component('ConsumableItems/Index')
-            ->has('errors.quantity')
-            ->where('errors.quantity', '数量には、500以下の数字を指定してください。')
-            // ->dump()
+        $response->assertInertia(fn(Assert $page) => $page
+                ->component('ConsumableItems/Index')
+                ->has('errors.quantity')
+                ->where('errors.quantity', '数量には、500以下の数字を指定してください。')
+                // ->dump()
         );
     }
 }

--- a/tests/Feature/Models/ItemTest.php
+++ b/tests/Feature/Models/ItemTest.php
@@ -2,26 +2,24 @@
 
 namespace Tests\Feature\Models;
 
-use App\Models\Item;
+use App\Models\AcquisitionMethod;
 use App\Models\Category;
+use App\Models\Disposal;
+use App\Models\Inspection;
+use App\Models\Item;
 use App\Models\Location;
 use App\Models\Unit;
 use App\Models\UsageStatus;
-use App\Models\AcquisitionMethod;
-use App\Models\Disposal;
-use App\Models\Inspection;
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
-use Tests\TestCase;
 use Illuminate\Database\Eloquent\Collection;
-
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
 
 class ItemTest extends TestCase
 {
     use RefreshDatabase;
 
     /** @test */
-    function categoryリレーションを返す()
+    public function categoryリレーションを返す()
     {
         $item = Item::factory()->create();
 
@@ -29,7 +27,7 @@ class ItemTest extends TestCase
     }
 
     /** @test */
-    function unitリレーションを返す()
+    public function unitリレーションを返す()
     {
         $item = Item::factory()->create();
 
@@ -37,15 +35,15 @@ class ItemTest extends TestCase
     }
 
     /** @test */
-    function usageStatusリレーションを返す()
+    public function usageStatusリレーションを返す()
     {
         $item = Item::factory()->create();
 
         $this->assertInstanceOf(UsageStatus::class, $item->usageStatus);
     }
-    
+
     /** @test */
-    function locationOfUseリレーションを返す()
+    public function locationOfUseリレーションを返す()
     {
         $item = Item::factory()->create();
 
@@ -53,7 +51,7 @@ class ItemTest extends TestCase
     }
 
     /** @test */
-    function storageLocationリレーションを返す()
+    public function storageLocationリレーションを返す()
     {
         $item = Item::factory()->create();
 
@@ -61,7 +59,7 @@ class ItemTest extends TestCase
     }
 
     /** @test */
-    function acquisitionMethodリレーションを返す()
+    public function acquisitionMethodリレーションを返す()
     {
         $item = Item::factory()->create();
 
@@ -69,7 +67,7 @@ class ItemTest extends TestCase
     }
 
     /** @test */
-    function inspectionsリレーションを返す()
+    public function inspectionsリレーションを返す()
     {
         $item = Item::factory()->create();
 
@@ -84,7 +82,7 @@ class ItemTest extends TestCase
     }
 
     /** @test */
-    function disposalリレーションを返す()
+    public function disposalリレーションを返す()
     {
         $item = Item::factory()->create();
 
@@ -96,7 +94,7 @@ class ItemTest extends TestCase
     }
 
     /** @test */
-    function stockTransactionsリレーションを返す()
+    public function stockTransactionsリレーションを返す()
     {
         $item = Item::factory()->create();
 

--- a/tests/Feature/Notification/InspectionAndDisposalScheduleNotificationTest.php
+++ b/tests/Feature/Notification/InspectionAndDisposalScheduleNotificationTest.php
@@ -2,49 +2,47 @@
 
 namespace Tests\Feature\Notification;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
-use Tests\TestCase;
+use App\Models\Disposal;
+use App\Models\Inspection;
 use App\Models\Item;
 use App\Models\User;
-use App\Models\Inspection;
-use App\Models\Disposal;
 use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Artisan;
-use App\Console\Commands\InspectionSchedule;
+use Tests\TestCase;
 
 class InspectionAndDisposalScheduleNotificationTest extends TestCase
 {
     use RefreshDatabase;
 
     /** @test */
-    function InspectionScheduleNotificationのテスト()
+    public function InspectionScheduleNotificationのテスト()
     {
         // 通知を送るすべてのタイミングの点検日を準備
         $inspections = Inspection::withoutEvents(function () {
             return [
                 Inspection::factory()->create([
-                    'item_id' => Item::factory()->create(['name' => 'テストアイテム1'])->id,
+                    'item_id'                   => Item::factory()->create(['name' => 'テストアイテム1'])->id,
                     'inspection_scheduled_date' => Carbon::today()->addWeeks(4),
                 ]),
                 Inspection::factory()->create([
-                    'item_id' => Item::factory()->create(['name' => 'テストアイテム2'])->id,
+                    'item_id'                   => Item::factory()->create(['name' => 'テストアイテム2'])->id,
                     'inspection_scheduled_date' => Carbon::today()->addWeeks(2),
                 ]),
                 Inspection::factory()->create([
-                    'item_id' => Item::factory()->create(['name' => 'テストアイテム3'])->id,
+                    'item_id'                   => Item::factory()->create(['name' => 'テストアイテム3'])->id,
                     'inspection_scheduled_date' => Carbon::today()->addWeek(),
                 ]),
                 Inspection::factory()->create([
-                    'item_id' => Item::factory()->create(['name' => 'テストアイテム4'])->id,
+                    'item_id'                   => Item::factory()->create(['name' => 'テストアイテム4'])->id,
                     'inspection_scheduled_date' => Carbon::today()->addDays(3),
                 ]),
                 Inspection::factory()->create([
-                    'item_id' => Item::factory()->create(['name' => 'テストアイテム5'])->id,
+                    'item_id'                   => Item::factory()->create(['name' => 'テストアイテム5'])->id,
                     'inspection_scheduled_date' => Carbon::today()->addDay(),
                 ]),
                 Inspection::factory()->create([
-                    'item_id' => Item::factory()->create(['name' => 'テストアイテム6'])->id,
+                    'item_id'                   => Item::factory()->create(['name' => 'テストアイテム6'])->id,
                     'inspection_scheduled_date' => Carbon::today(),
                 ]),
             ];
@@ -61,15 +59,15 @@ class InspectionAndDisposalScheduleNotificationTest extends TestCase
         // 通知がデータベースに保存されていることをアサート
         foreach ($users as $user) {
             $this->assertDatabaseHas('notifications', [
-                'notifiable_id' => $user->id,
+                'notifiable_id'   => $user->id,
                 'notifiable_type' => User::class,
                 // 'type' => InspectionScheduleNotification::class,
             ]);
 
             // 通知内容を検証
             $notifications = $user->notifications;
-            $this->assertCount(6, $notifications); 
-            
+            $this->assertCount(6, $notifications);
+
             foreach ($notifications as $notification) {
                 // それぞれの$itemのidを取得
                 $item = Item::find($notification->data['id']);
@@ -82,33 +80,33 @@ class InspectionAndDisposalScheduleNotificationTest extends TestCase
     }
 
     /** @test */
-    function DisposalScheduleNotificationのテスト()
+    public function DisposalScheduleNotificationのテスト()
     {
         // 通知を送るすべてのタイミングの点検日を作成、DisposalObserverは無効化
         $disposals = Disposal::withoutEvents(function () {
             return [
                 Disposal::factory()->create([
-                    'item_id' => Item::factory()->create(['name' => 'テストアイテム1'])->id,
+                    'item_id'                 => Item::factory()->create(['name' => 'テストアイテム1'])->id,
                     'disposal_scheduled_date' => Carbon::today()->addWeeks(4),
                 ]),
                 Disposal::factory()->create([
-                    'item_id' => Item::factory()->create(['name' => 'テストアイテム2'])->id,
+                    'item_id'                 => Item::factory()->create(['name' => 'テストアイテム2'])->id,
                     'disposal_scheduled_date' => Carbon::today()->addWeeks(2),
                 ]),
                 Disposal::factory()->create([
-                    'item_id' => Item::factory()->create(['name' => 'テストアイテム3'])->id,
+                    'item_id'                 => Item::factory()->create(['name' => 'テストアイテム3'])->id,
                     'disposal_scheduled_date' => Carbon::today()->addWeek(),
                 ]),
                 Disposal::factory()->create([
-                    'item_id' => Item::factory()->create(['name' => 'テストアイテム4'])->id,
+                    'item_id'                 => Item::factory()->create(['name' => 'テストアイテム4'])->id,
                     'disposal_scheduled_date' => Carbon::today()->addDays(3),
                 ]),
                 Disposal::factory()->create([
-                    'item_id' => Item::factory()->create(['name' => 'テストアイテム5'])->id,
+                    'item_id'                 => Item::factory()->create(['name' => 'テストアイテム5'])->id,
                     'disposal_scheduled_date' => Carbon::today()->addDay(),
                 ]),
                 Disposal::factory()->create([
-                    'item_id' => Item::factory()->create(['name' => 'テストアイテム6'])->id,
+                    'item_id'                 => Item::factory()->create(['name' => 'テストアイテム6'])->id,
                     'disposal_scheduled_date' => Carbon::today(),
                 ]),
             ];
@@ -126,14 +124,14 @@ class InspectionAndDisposalScheduleNotificationTest extends TestCase
         // 通知がデータベースに保存されていることをアサート
         foreach ($users as $user) {
             $this->assertDatabaseHas('notifications', [
-                'notifiable_id' => $user->id,
+                'notifiable_id'   => $user->id,
                 'notifiable_type' => User::class,
                 // 'type' => DisposalScheduleNotification::class,
             ]);
 
             // 通知内容を検証
             $notifications = $user->notifications;
-            $this->assertCount(6, $notifications); 
+            $this->assertCount(6, $notifications);
 
             foreach ($notifications as $notification) {
                 // それぞれの$itemのidを取得

--- a/tests/Feature/Notification/LowStockNotificationTest.php
+++ b/tests/Feature/Notification/LowStockNotificationTest.php
@@ -2,25 +2,22 @@
 
 namespace Tests\Feature\Notification;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
-use Tests\TestCase;
+use App\Events\LowStockDetectEvent;
+use App\Models\Category;
 use App\Models\Item;
 use App\Models\User;
-use App\Models\Category;
-use Illuminate\Support\Facades\Event;
-use Illuminate\Support\Facades\Notification;
-use App\Events\LowStockDetectEvent;
-use App\Listeners\LowStockDetectListener;
 use App\Notifications\LowStockNotification;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Event;
+use Tests\TestCase;
 
 class LowStockNotificationTest extends TestCase
 {
     use RefreshDatabase;
 
     /** @test */
-    function LowStockNotificationのテスト()
+    public function LowStockNotificationのテスト()
     {
         // categoriesテーブルをトランケートして連番をリセット
         DB::statement('SET FOREIGN_KEY_CHECKS=0;');
@@ -35,10 +32,10 @@ class LowStockNotificationTest extends TestCase
         ]);
 
         // テスト用のアイテムを作成
-        $category = Category::factory()->create(['id' => 1]);   
-        $item = Item::factory()->create([
-            'category_id' => $category->id,
-            'stock' => 2,
+        $category = Category::factory()->create(['id' => 1]);
+        $item     = Item::factory()->create([
+            'category_id'   => $category->id,
+            'stock'         => 2,
             'minimum_stock' => 5,
         ]);
 
@@ -48,9 +45,9 @@ class LowStockNotificationTest extends TestCase
         // 通知がデータベースに保存されたことをアサート
         foreach ($users as $user) {
             $this->assertDatabaseHas('notifications', [
-                'notifiable_id' => $user->id,
+                'notifiable_id'   => $user->id,
                 'notifiable_type' => User::class,
-                'type' => LowStockNotification::class,
+                'type'            => LowStockNotification::class,
             ]);
 
             // 通知内容を検証

--- a/tests/Feature/Notification/RequestedItemNotificationTest.php
+++ b/tests/Feature/Notification/RequestedItemNotificationTest.php
@@ -2,28 +2,26 @@
 
 namespace Tests\Feature\Notification;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
-use Tests\TestCase;
 use App\Events\RequestedItemDetectEvent;
-use App\Listeners\RequestedItemDetectListener;
-use App\Models\User;
 use App\Models\ItemRequest;
+use App\Models\User;
 use App\Notifications\RequestedItemNotification;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
 
 class RequestedItemNotificationTest extends TestCase
 {
     use RefreshDatabase;
 
     /** @test */
-    function RequestedItemNotificationのテスト()
+    public function RequestedItemNotificationのテスト()
     {
         // 送信するユーザーを世界に構築
         $users = User::factory()->createMany([
             ['role' => 1],
             ['role' => 5],
         ]);
-        
+
         $itemRequest = ItemRequest::factory()->create();
 
         // LowStockDetectEventを発火
@@ -32,9 +30,9 @@ class RequestedItemNotificationTest extends TestCase
         // 通知がデータベースに保存されたことをアサート
         foreach ($users as $user) {
             $this->assertDatabaseHas('notifications', [
-                'notifiable_id' => $user->id,
+                'notifiable_id'   => $user->id,
                 'notifiable_type' => User::class,
-                'type' => RequestedItemNotification::class,
+                'type'            => RequestedItemNotification::class,
             ]);
 
             // 通知内容を検証

--- a/tests/Feature/Services/ImageServiceTest.php
+++ b/tests/Feature/Services/ImageServiceTest.php
@@ -2,15 +2,14 @@
 
 namespace Tests\Feature\Services;
 
+use App\Services\ImageService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
-use Tests\TestCase;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Storage;
-use App\Services\ImageService;
+use Intervention\Image\Drivers\Imagick\Driver;
 use Intervention\Image\ImageManager;
 // use Intervention\Image\Drivers\Gd\Driver;
-use Intervention\Image\Drivers\Imagick\Driver;
+use Tests\TestCase;
 
 class ImageServiceTest extends TestCase
 {
@@ -18,7 +17,7 @@ class ImageServiceTest extends TestCase
 
     // ItemControllerのstore,updateの画像アップロード
     /** @test */
-    function resizeUploadのテスト()
+    public function resizeUploadのテスト()
     {
         Storage::fake('public');
 
@@ -28,11 +27,11 @@ class ImageServiceTest extends TestCase
 
         dump($fileNameToStore);
 
-        Storage::disk()->assertExists('items/'.$fileNameToStore);
+        Storage::disk()->assertExists('items/' . $fileNameToStore);
     }
 
     /** @test */
-    function profileImageResizeUploadのテスト()
+    public function profileImageResizeUploadのテスト()
     {
         Storage::fake('public');
 
@@ -42,11 +41,11 @@ class ImageServiceTest extends TestCase
 
         // dd($fileNameToStore);
 
-        Storage::disk()->assertExists('profile/'.$fileNameToStore);
+        Storage::disk()->assertExists('profile/' . $fileNameToStore);
     }
 
     /** @test */
-    function InterventionImageテスト()
+    public function InterventionImageテスト()
     {
         // テスト用の画像ファイルを準備
         Storage::fake('public');
@@ -55,12 +54,12 @@ class ImageServiceTest extends TestCase
         try {
             // 画像を処理するコード
             $manager = new ImageManager(new Driver());
-            $image = $manager->read($image->getPathname());
+            $image   = $manager->read($image->getPathname());
         } catch (\Intervention\Image\Exception\NotReadableException $e) {
             Log::error('Image not readable: ' . $e->getMessage());
             $this->fail('Image processing failed: ' . $e->getMessage());
         }
-    
+
         $this->assertTrue(true);
     }
 }

--- a/tests/Feature/Services/ManagementIdServiceTest.php
+++ b/tests/Feature/Services/ManagementIdServiceTest.php
@@ -2,31 +2,30 @@
 
 namespace Tests\Feature\Services;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
-use Tests\TestCase;
 use App\Services\ManagementIdService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Validation\ValidationException;
+use Tests\TestCase;
 
 class ManagementIdServiceTest extends TestCase
 {
     use RefreshDatabase;
 
     /** @test */
-    function ManagementIdServiceがすべての接頭辞で管理IDを作成できるかテスト()
+    public function ManagementIdServiceがすべての接頭辞で管理IDを作成できるかテスト()
     {
         $idPrefixPairs = [
-            1 => 'CO-',
-            2 => 'IT-',
-            3 => 'SA-',
-            4 => 'EA-',
-            5 => 'DP-',
-            6 => 'OS-',
-            7 => 'OF-',
-            8 => 'TO-',
-            9 => 'CL-',
+            1  => 'CO-',
+            2  => 'IT-',
+            3  => 'SA-',
+            4  => 'EA-',
+            5  => 'DP-',
+            6  => 'OS-',
+            7  => 'OF-',
+            8  => 'TO-',
+            9  => 'CL-',
             10 => 'GR-',
-            11 => 'OT-'
+            11 => 'OT-',
         ];
 
         foreach ($idPrefixPairs as $category_id => $prefix) {


### PR DESCRIPTION
## 目的

LaravelのFeatureテストのテストコードをすべてフォーマットする。

## 関連Issue

このセクションでは、このPRが関連するIssueやタスクをリンクしてください。以下のように記述します。

- 関連Issue: #315

## 変更点

- 変更点1
テストコードをフォーマッターを使用して、フォーマットしました。