### PR TITLE
fix:#321  #426 点検と廃棄の通知がartisanコマンドで来るよう修正

### DIFF
--- a/app/Console/Commands/DisposalSchedule.php
+++ b/app/Console/Commands/DisposalSchedule.php
@@ -30,12 +30,12 @@ class DisposalSchedule extends Command
     public function handle()
     {
         $dates = [
-            Carbon::today()->addWeeks(4),
-            Carbon::today()->addWeeks(2),
-            Carbon::today()->addWeek(),
-            Carbon::today()->addDays(3),
-            Carbon::today()->addDay(),
-            Carbon::today(),
+            Carbon::today()->addWeeks(4)->toDateString(),
+            Carbon::today()->addWeeks(2)->toDateString(),
+            Carbon::today()->addWeek()->toDateString(),
+            Carbon::today()->addDays(3)->toDateString(),
+            Carbon::today()->addDay()->toDateString(),
+            Carbon::today()->toDateString(),
         ];
 
         $disposals = Disposal::whereIn('disposal_scheduled_date', $dates)->get();
@@ -43,7 +43,7 @@ class DisposalSchedule extends Command
         \Log::info('sendDisposalNotifications called');
 
         foreach ($disposals as $disposal) {
-            $users = User::whereIn('role', [1, 5])->get(); // roleが1（admin）または5（staff）のユーザーを取得
+            $users = User::whereIn('role', [0, 1, 5])->get(); // roleが1（admin）または5（staff）のユーザーを取得
             foreach ($users as $user) {
                 $user->notify(new DisposalScheduleNotification($disposal));
             }

--- a/app/Console/Commands/InspectionSchedule.php
+++ b/app/Console/Commands/InspectionSchedule.php
@@ -30,12 +30,12 @@ class InspectionSchedule extends Command
     public function handle()
     {
         $dates = [
-            Carbon::today()->addWeeks(4),
-            Carbon::today()->addWeeks(2),
-            Carbon::today()->addWeek(),
-            Carbon::today()->addDays(3),
-            Carbon::today()->addDay(),
-            Carbon::today(),
+            Carbon::today()->addWeeks(4)->toDateString(),
+            Carbon::today()->addWeeks(2)->toDateString(),
+            Carbon::today()->addWeek()->toDateString(),
+            Carbon::today()->addDays(3)->toDateString(),
+            Carbon::today()->addDay()->toDateString(),
+            Carbon::today()->toDateString(),
         ];
 
         $inspections = Inspection::whereIn('inspection_scheduled_date', $dates)->get();
@@ -43,7 +43,7 @@ class InspectionSchedule extends Command
         \Log::info('sendInspectionNotifications called'); // ログを記録
 
         foreach ($inspections as $inspection) {
-            $users = User::whereIn('role', [1, 5])->get(); // roleが1（admin）または5（staff）のユーザーを取得
+            $users = User::whereIn('role', [0, 1, 5])->get(); // roleが1（admin）または5（staff）のユーザーを取得
             foreach ($users as $user) {
                 $user->notify(new InspectionScheduleNotification($inspection));
             }

--- a/database/seeders/DisposalSeeder.php
+++ b/database/seeders/DisposalSeeder.php
@@ -37,7 +37,7 @@ class DisposalSeeder extends Seeder
             [
                 'id'                      => 3,
                 'item_id'                 => 73,
-                'disposal_scheduled_date' => '2025-03-27',
+                'disposal_scheduled_date' => '2025-03-20',
                 'disposal_date'           => null,
                 'disposal_person'         => null,
                 'details'                 => null,

--- a/database/seeders/InspectionSeeder.php
+++ b/database/seeders/InspectionSeeder.php
@@ -50,7 +50,7 @@ class InspectionSeeder extends Seeder
             [
                 'id'                        => 4,
                 'item_id'                   => 87,
-                'inspection_scheduled_date' => '2025/3/27',
+                'inspection_scheduled_date' => '2025/3/7',
                 'inspection_date'           => null,
                 'status'                    => 0,
                 'inspection_person'         => null,


### PR DESCRIPTION
## 目的

通知画面で「点検・廃棄予定」タブの通知が、artisanコマンドで来るよう修正しました。

## 関連Issue

- 関連Issue: #321 
- 関連Issue: #426

## 変更点

- 変更点1
InspectionScheduleおよびDisposalSchedule内のCarbonで表現していた日付の形式が、
DBの日付の形式と合っていなかったので修正しました。
日付の形式が合っていなかったため、通知が送られていませんでした。

- 変更点2
ゲストユーザー(role=0)にも通知が送られるよう修正しました。

- 変更点3
本番環境でも通知が適切に送られるか確認するため、
InspectionSeederおよびDisposalSeederの予定日の日付を修正しました。