### PR TITLE
fix:#427 500エラーが出たので修正

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -39,9 +39,6 @@ class AppServiceProvider extends ServiceProvider
         if ($this->app->environment('production')) {
             URL::forceScheme('https');
             $this->app['request']->server->set('HTTPS', 'on');
-        } else {
-            $this->app['request']->server->set('HTTPS', 'off');
         }
-        
     }
 }


### PR DESCRIPTION
## 目的

AppSeviceProviderを変更したところ500エラーが発生したので、正常にHTTPSで通信できるように修正する。

## 関連Issue

- 関連Issue: #427

## 変更点

- 変更点1
条件分岐の開発環境用のコードを削除。