### PR TITLE
fix:#321 Amazon EventBridgeでのCronの時間をUTC時間に合わせて修正

### DIFF
--- a/cloudformation/eventbridge.yml
+++ b/cloudformation/eventbridge.yml
@@ -4,7 +4,7 @@ Resources:
     Type: "AWS::Events::Rule"
     Properties:
       Name: "LaravelInspectionSchedule"
-      ScheduleExpression: "cron(0 0 * * ? *)"
+      ScheduleExpression: "cron(0 15 * * ? *)"
       State: "ENABLED"
       Targets:
         - Id: "EcsTask"
@@ -28,7 +28,7 @@ Resources:
     Type: "AWS::Events::Rule"
     Properties:
       Name: "LaravelDisposalSchedule"
-      ScheduleExpression: "cron(0 0 * * ? *)"
+      ScheduleExpression: "cron(0 15 * * ? *)"
       State: "ENABLED"
       Targets:
         - Id: "EcsTask"


### PR DESCRIPTION
## 目的

AWSのAmazon EventBrigdeルールのCronの時間設定をUTC時間に修正。

## 関連Issue

- 関連Issue: #321

## 変更点

- 変更点1
CloudFormationのスタックにアップするeventbridge.ymlを修正しました。
UTC時間と比較して日本時間は9時間進んでいるため、UTC時間で15時に通知を送るよう設定。