### PR TITLE
fix:#204 キャッチコピーの文章にNoto Sans JPを適用

### DIFF
--- a/resources/js/Pages/Welcome.vue
+++ b/resources/js/Pages/Welcome.vue
@@ -47,9 +47,11 @@ onMounted(() => {
             style="background-image: url('/images/office_layer.png'); background-color: #eef2ff; background-size: cover; background-position: left;">
             <div class="container mx-auto px-20 py-8 grid grid-cols-1 md:grid-cols-2">
                 <div class="flex flex-col justify-center order-2 md:order-1">
-                    <h1 class="pt-4 md:pt-0 text-2xl font-bold leading-normal tracking-widest text-center">
-                        利用者も参加できる備品管理システム<br>
-                        事業所の生産性と満足度を上げよう<br>
+                    <h1 class="pt-4 md:pt-0 font-noto-sans-jp text-2xl font-bold leading-normal tracking-widest text-center">
+                        <P class="font-normal">
+                            利用者も参加できる備品管理システム<br>
+                            事業所の生産性と満足度を上げよう<br>
+                        </P>
                     </h1>
                     <div v-if="canLogin" class="mt-4 flex justify-center">
                         <Link

--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -9,6 +9,10 @@
         <!-- Fonts -->
         <link rel="preconnect" href="https://fonts.bunny.net">
         <link href="https://fonts.bunny.net/css?family=figtree:400,500,600&display=swap" rel="stylesheet" />
+        
+        <link rel="preconnect" href="https://fonts.googleapis.com">
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+        <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP&family=Noto+Sans:ital,wght@0,100..900;1,100..900&display=swap" rel="stylesheet">
 
         <!-- Scripts -->
         @routes

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -14,6 +14,7 @@ export default {
         extend: {
             fontFamily: {
                 sans: ['Figtree', ...defaultTheme.fontFamily.sans],
+                'noto-sans-jp': ['Noto Sans JP', 'sans-serif'],
             },
         },
     },


### PR DESCRIPTION
## 目的

Welcome.vueのキャチコピーの文章にGoogle FontsのNoto Sans JPを適用する。

## 関連Issue

このセクションでは、このPRが関連するIssueやタスクをリンクしてください。以下のように記述します。

- 関連Issue: #204

## 変更点

- 変更点1
app.blade.phpのlinkタグでGoogle FontsのNoto Sans JPを読み込み、
tailwind.config.jsでTailwindCSSのクラスとして登録、
Welcome.vueでクラスを使用しました。