### PR TITLE
fix:#435 QRコードのラベル生成を本番環境のS3に合わせて修正

### DIFF
--- a/app/Services/QrCodeService.php
+++ b/app/Services/QrCodeService.php
@@ -22,10 +22,9 @@ class QrCodeService
             $qrCode            = QrCode::format('png')->size(300)->generate($item->id); // $item->idを元にQRコードを生成
             $qrCodeNameToStore = 'QR-' . uniqid(rand() . '_') . '.png';
             Storage::disk()->put('qrcode/' . $qrCodeNameToStore, $qrCode);
-            $qrCodefilePath = Storage::disk()->path('qrcode/' . $qrCodeNameToStore);
 
             $qrManager = new ImageManager(new Driver());
-            $qrImage   = $qrManager->read($qrCodefilePath);
+            $qrImage   = $qrManager->read(Storage::disk()->get('qrcode/' . $qrCodeNameToStore));
 
             $label = $qrManager->create(910, 550)->fill('fff'); //白地に画像と文字列を合成
             $label->place($qrImage, 'top-left', 40, 125);


### PR DESCRIPTION
## 目的

AWSの本番環境でQRコードが生成できないバグを修正する。

## 関連Issue

- 関連Issue: #435

## 変更点

- 変更点1
Storage::disk()->path('qrcode/' . $qrCodeNameToStore)はローカル環境でしか使えないので、
Storage::disk()->get('qrcode/' . $qrCodeNameToStore)に変更しました。