### PR TITLE
fix:#435 s3からフォントを取得する方法を修正

### DIFF
--- a/app/Services/QrCodeService.php
+++ b/app/Services/QrCodeService.php
@@ -29,18 +29,22 @@ class QrCodeService
             $label = $qrManager->create(910, 550)->fill('fff'); //白地に画像と文字列を合成
             $label->place($qrImage, 'top-left', 40, 125);
 
-            $label->text('管理ID' . $item->management_id, 370, 160, function (FontFactory $font) {
-                $font->filename(public_path('storage/fonts/NotoSansJP-Medium.ttf'));
+            // S3からフォントファイルを取得し、テンポラリファイルに保存
+            $fontPath = tempnam(sys_get_temp_dir(), 'font');
+            file_put_contents($fontPath, Storage::disk()->get('fonts/NotoSansJP-Medium.ttf'));
+
+            $label->text('管理ID' . $item->management_id, 370, 160, function (FontFactory $font) use ($fontPath) {
+                $font->file($fontPath);
                 $font->size(30);
                 $font->color('#000');
             });
-            $label->text('備品名 ' . $item->name, 370, 230, function (FontFactory $font) {
-                $font->filename(public_path('storage/fonts/NotoSansJP-Medium.ttf'));
+            $label->text('備品名 ' . $item->name, 370, 230, function (FontFactory $font) use ($fontPath) {
+                $font->file($fontPath);
                 $font->size(30);
                 $font->color('#000');
             });
-            $label->text('カテゴリ' . $item->category->name, 370, 300, function (FontFactory $font) {
-                $font->filename(public_path('storage/fonts/NotoSansJP-Medium.ttf'));
+            $label->text('カテゴリ' . $item->category->name, 370, 300, function (FontFactory $font) use ($fontPath) {
+                $font->file($fontPath);
                 $font->size(30);
                 $font->color('#000');
             });
@@ -62,6 +66,11 @@ class QrCodeService
             ]);
 
             throw $e; // エラーを再スローしてコントローラでキャッチできるように
+        } finally {
+            // 一時ファイルの削除
+            if (isset($fontPath)) {
+                unlink($fontPath);
+            }
         }
     }
 }


### PR DESCRIPTION
## 目的

AWSの本番環境でQRコードが生成できないバグを修正する。

## 関連Issue

このセクションでは、このPRが関連するIssueやタスクをリンクしてください。以下のように記述します。

- 関連Issue: #435 

## 変更点

- 変更点1
QRコードラベルを生成する際に使用するフォントファイルが読み込めていなかったので、
PHPの関数で一時ファイルを生成し、そこにフォントファイルのバイナリデータを書き込む方法に修正しました。