### PR TITLE
fix:vCPUとメモリの性能を変更

### DIFF
--- a/.aws/task-def-portfolio.json
+++ b/.aws/task-def-portfolio.json
@@ -42,8 +42,8 @@
     "requiresCompatibilities": [
         "FARGATE"
     ],
-    "cpu": "512",
-    "memory": "1024",
+    "cpu": "1024",
+    "memory": "2048",
     "runtimePlatform": {
         "cpuArchitecture": "X86_64",
         "operatingSystemFamily": "LINUX"


### PR DESCRIPTION
## 目的

タスク定義のvCPUとメモリの性能を上げるとどれくらいパフォーマンスが変わるか確認する。

## 関連Issue

- 関連Issue: #438

## 変更点

- 変更点1
タスク定義のvCPUを512から1024に、メモリを1024から2048へ変更しました。