### PR TITLE
CICD/自動デプロイの実行条件をpushに変更、paths-ignoreで対象から除外するファイルを追加

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,11 +1,11 @@
 name: EMS Deploy Pipeline
 on:
-  pull_request:  #プルリクのマージ時自動デプロイ
-    types: [closed]
+  push:  #プルリクエストのマージ時自動デプロイ
     branches: 
       - main
-    paths:
-      - '**'
+    paths-ignore:
+      - 'README.md'
+      - 'public/images/**'
 
 env:
   AWS_REGION: ap-northeast-1


### PR DESCRIPTION
## 目的

自動デプロイが実行される条件を適切なものに修正すること。

## 関連Issue

- 関連Issue: #442

## 変更点

- 変更点1
ci.ymlファイルで、自動デプロイが実行される条件を「pull_request」から「push」に変更しました。

- 変更点2
ci.ymlファイルで、mainブランチにマージされても自動デプロイさせたくないファイルを設定しました。
paths-igonreに「README.md」「public/images/以下の画像ファイル」を設定しました。