### PR TITLE
CICD:#443 自動デプロイがスキップされるようになってしまったので一旦元に戻す

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,11 +1,11 @@
 name: EMS Deploy Pipeline
 on:
-  push:  #プルリクエストのマージ時自動デプロイ
+  pull_request:  #プルリクのマージ時自動デプロイ
+    types: [closed]
     branches: 
       - main
-    paths-ignore:
-      - 'README.md'
-      - 'public/images/**'
+    paths:
+      - '**'
 
 env:
   AWS_REGION: ap-northeast-1


### PR DESCRIPTION
## 目的

pushを条件とした自動デプロイが上手く機能しないので、一度設定をpull_requestに戻します。

## 関連Issue

- 関連Issue: #442

## 変更点

- 変更点1
ci.ymlの自動デプロイの条件をpushからpull_requestに戻しました。
理由として、自動デプロイが上手く行われなかったためです。
他にもデプロイしたい項目があるため、一旦元に戻します。