### PR TITLE
Fix/画面遷移でbell notificaiton.vueの同一のapi通信が2度発生している現象を解決する

### DIFF
--- a/resources/js/Components/BellNotification.vue
+++ b/resources/js/Components/BellNotification.vue
@@ -3,36 +3,20 @@ import axios from 'axios';
 import { Link } from '@inertiajs/vue3';
 import { onMounted, ref } from 'vue';
 
-import type { Ref } from 'vue';
+import type { PropType, Ref } from 'vue';
 import type { NotificationType } from '@/@types/model';
 
 // 通常のNavLinkの場合はリンクとして、ResponsiveNavLinkの場合はただのアイコンとして使用
 defineProps({
+  notifications: {
+    type: Array as PropType<NotificationType[]>,
+    required: true
+  },
   isLink: {
     type: Boolean,
     required: true
   },
 });
-
-const notifications: Ref<NotificationType[]> = ref([]);
-const isFetched: Ref<boolean> = ref(false);
-
-const fetchNotifications = async (): Promise<void> => {
-  if (!isFetched.value) {
-    try {
-      const res = await axios.get('/api/notifications_count');
-      notifications.value = res.data;
-      isFetched.value = true;
-    } catch (e: any) {
-      axios.post('/api/log-error', {
-        error: e.toString(),
-        component: 'BellNotification.vue onMounted axios.get',
-      });
-    }
-  }
-};
-
-onMounted(fetchNotifications);
 </script>
 
 <template>

--- a/resources/js/Components/BellNotification.vue
+++ b/resources/js/Components/BellNotification.vue
@@ -15,20 +15,24 @@ defineProps({
 });
 
 const notifications: Ref<NotificationType[]> = ref([]);
+const isFetched: Ref<boolean> = ref(false);
 
-onMounted(async (): Promise<void> => {
-  try {
-    await axios.get('/api/notifications_count')
-    .then(res => {
+const fetchNotifications = async (): Promise<void> => {
+  if (!isFetched.value) {
+    try {
+      const res = await axios.get('/api/notifications_count');
       notifications.value = res.data;
-    });
-  } catch (e: any) {
-    axios.post('/api/log-error', {
-      error: e.toString(),
-      component: 'BellNotification.vue onMounted axios.get',
-    });
+      isFetched.value = true;
+    } catch (e: any) {
+      axios.post('/api/log-error', {
+        error: e.toString(),
+        component: 'BellNotification.vue onMounted axios.get',
+      });
+    }
   }
-});
+};
+
+onMounted(fetchNotifications);
 </script>
 
 <template>


### PR DESCRIPTION
## 目的

画面遷移でBellNotificaiton.vueの同一のAPI通信が2度発生している現象を解決する。

## 関連Issue

- 関連Issue: #440

## 変更点

- 変更点1
BellNotification.vueの非同期通信部分をAuthenticatedLayout.vueに移動しました。
通知数はBellNotification.vueのコンポーネントにprops downで渡すことにしました。

- 変更点2
AuthenticatedLayout.vueのレスポンシブデザインの方のBellNotification.vueに、
ユーザーのroleによるv-ifでの表示・非表示のコードが抜けていたので追加しました。