### PR TITLE
fix:#461 ICONSVGのライセンス表記を追加しました

### DIFF
--- a/resources/js/Layouts/AuthenticatedLayout.vue
+++ b/resources/js/Layouts/AuthenticatedLayout.vue
@@ -228,15 +228,33 @@ onMounted(async () => {
         <p>&copy; 2024 waya. All rights reserved.</p>
         <p>
           Icons provided by
-          <a href="https://heroicons.com/" target="_blank" class="text-blue-500">Heroicons</a>
-          . Licensed under the MIT License.
+          <a 
+            href="https://heroicons.com/"
+            target="_blank"
+            class="text-blue-500"
+            >Heroicons</a>
+          and
+          <a 
+            href="https://iconsvg.xyz/"
+            target="_blank"
+            class="text-blue-500"
+            >ICONSVG</a>.
+          Both are licensed under the MIT License.
         </p>
         <p>
           Fonts provided by
-          <a href="https://fonts.google.com/" target="_blank" class="text-blue-500">Google Fonts</a>. Licensed under the
-          <a href="https://scripts.sil.org/cms/scripts/page.php?item_id=OFL_web" target="_blank"
-            class="text-blue-500">Open
-            Font License</a>.
+          <a
+            href="https://fonts.google.com/"
+            target="_blank"
+            class="text-blue-500"
+            >Google Fonts</a>
+            . Licensed under the
+          <a 
+            href="https://scripts.sil.org/cms/scripts/page.php?item_id=OFL_web"
+            target="_blank"
+            class="text-blue-500">
+            Open Font License</a>
+          .
         </p>
       </footer>
     </div>

--- a/resources/js/Pages/Welcome.vue
+++ b/resources/js/Pages/Welcome.vue
@@ -189,14 +189,20 @@ defineProps({
     <footer class="bg-gray-100 text-gray-400 text-center text-sm py-4">
       <p>&copy; 2024 waya. All rights reserved.</p>
       <p>
-        Icons provided by
-        <a
-          href="https://heroicons.com/"
-          target="_blank"
-          class="text-blue-500"
-          >Heroicons</a>
-        . Licensed under the MIT License.
-      </p>
+          Icons provided by
+          <a 
+            href="https://heroicons.com/"
+            target="_blank"
+            class="text-blue-500"
+            >Heroicons</a>
+          and
+          <a 
+            href="https://iconsvg.xyz/"
+            target="_blank"
+            class="text-blue-500"
+            >ICONSVG</a>.
+          Both are licensed under the MIT License.
+        </p>
       <p>
         Fonts provided by
         <a


### PR DESCRIPTION
## 目的

抜けていたICONSVGのライセンス表記を追加する。

## 関連Issue

- 関連Issue: #461

## 変更点

- 変更点1
AuthenticatedLayout.vueのフッターにICONSVGのライセンスを追加。

- 変更点2
Welcome.vueのフッターにICONSVGのライセンスを追加。