### PR TITLE
fix:#321 ワークフローのデプロイとEventBridgeルール作成のyamlファイルを2つに分離

### DIFF
--- a/.github/workflows/cd-eventbridge.yml
+++ b/.github/workflows/cd-eventbridge.yml
@@ -1,0 +1,42 @@
+name: Deploy EventBridge Rule
+
+on:
+  workflow_dispatch:  # 手動実行用（必要なら schedule や push にも対応可）
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  AWS_REGION: ap-northeast-1
+
+jobs:
+  deploy-eventbridge:
+    name: Deploy EventBridge Rule
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials using OIDC
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Prepare CloudFormation template for EventBridge
+        run: |
+          sed "s|__CLUSTER_ARN__|${{ secrets.ECS_CLUSTER_ARN }}|g" cloudformation/eventbridge.template.yml \
+          | sed "s|__ROLE_ARN__|${{ secrets.EXEC_ROLE_ARN }}|g" \
+          | sed "s|__TASK_DEF_ARN__|${{ secrets.TASK_DEF_ARN }}|g" \
+          | sed "s|__SUBNET_ID__|${{ secrets.SUBNET_ID }}|g" \
+          | sed "s|__SECURITY_GROUP_ID__|${{ secrets.SECURITY_GROUP_ID }}|g" \
+          > cloudformation/eventbridge.yml
+
+      - name: Deploy EventBridge rule via CloudFormation
+        run: |
+          aws cloudformation deploy \
+            --template-file cloudformation/eventbridge.yml \
+            --stack-name eventbridge-rule-stack \
+            --capabilities CAPABILITY_NAMED_IAM

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -19,7 +19,6 @@ permissions:
   contents: read
 
 jobs:
-# Test
 # Build
   build-and-push:
     if: github.event.pull_request.merged == true
@@ -139,20 +138,3 @@ jobs:
           service: ${{ env.ECS_SERVICE }}
           cluster: ${{ env.ECS_CLUSTER }}
           wait-for-service-stability: true
-
-      - name: Prepare EventBridge file from template
-        run: |
-          sed "s|__CLUSTER_ARN__|${{ secrets.ECS_CLUSTER_ARN }}|g" \
-          cloudformation/eventbridge.template.yml \
-          | sed "s|__ROLE_ARN__|${{ secrets.EXEC_ROLE_ARN }}|g" \
-          | sed "s|__TASK_DEF_ARN__|${{ secrets.TASK_DEF_ARN }}|g" \
-          | sed "s|__SUBNET_ID__|${{ secrets.SUBNET_ID }}|g" \
-          | sed "s|__SECURITY_GROUP_ID__|${{ secrets.SECURITY_GROUP_ID }}|g" \
-          > cloudformation/eventbridge.yml
-
-      - name: Deploy EventBridge Rule via CloudFormation
-        run: |
-          aws cloudformation deploy \
-            --template-file cloudformation/eventbridge.yml \
-            --stack-name eventbridge-rule-stack \
-            --capabilities CAPABILITY_NAMED_IAM


### PR DESCRIPTION
## 目的

Amazon EventBridgeに定期実行のルールを正しく設定すること。
定期実行するのは点検・廃棄予定の通知を送信するコマンドです。

## 関連Issue

- 関連Issue: #321 

## 変更点

- 変更点1
Amazon EventBridgeルール作成とデプロイでは使用する認証が異なるため、
cd.ymlファイルに書いていたAmazon EventBridge作成部分をcd-eventbridge.ymlとして分離しました。

- 変更点2
cd-eventbridge.yml部分ではOpenID Connectを使用した認証を使用しました。