### PR TITLE
fix:#321 Amazon EventBridgeルールのスタック名が指定出来ていなかったので修正

### DIFF
--- a/.github/workflows/cd-eventbridge.yml
+++ b/.github/workflows/cd-eventbridge.yml
@@ -38,5 +38,5 @@ jobs:
         run: |
           aws cloudformation deploy \
             --template-file cloudformation/eventbridge.yml \
-            --stack-name eventbridge-rule-stack \
+            --stack-name ECSLaravelInspectionDisposalEventBridgeRules \
             --capabilities CAPABILITY_NAMED_IAM


### PR DESCRIPTION
## 目的

Amazon EventBridgeに定期実行のルールを正しく設定すること。
定期実行するのは点検・廃棄予定の通知を送信するコマンドです。

## 関連Issue

- 関連Issue: #321 

## 変更点

- 変更点1
cd-eventbridge.ymlにAmazon EventBrigdgeルールのスタック名が正しく指定されていなかったため修正。

- 変更点2
AWSのロールのポリシーでもResource名を正しいスタック名に変更。