### PR TITLE
fix:#321 InspectionSeederの点検予定日、DisposalSeederの廃棄予定日に直近の日付を設定

### DIFF
--- a/database/seeders/DisposalSeeder.php
+++ b/database/seeders/DisposalSeeder.php
@@ -37,7 +37,7 @@ class DisposalSeeder extends Seeder
             [
                 'id'                      => 3,
                 'item_id'                 => 73,
-                'disposal_scheduled_date' => '2025-03-20',
+                'disposal_scheduled_date' => '2025-04-20',
                 'disposal_date'           => null,
                 'disposal_person'         => null,
                 'details'                 => null,

--- a/database/seeders/InspectionSeeder.php
+++ b/database/seeders/InspectionSeeder.php
@@ -17,7 +17,7 @@ class InspectionSeeder extends Seeder
             [
                 'id'                        => 1,
                 'item_id'                   => 84,
-                'inspection_scheduled_date' => '2025/10/05',
+                'inspection_scheduled_date' => '2025-10-05',
                 'inspection_date'           => null,
                 'status'                    => 0,
                 'inspection_person'         => null,
@@ -28,7 +28,7 @@ class InspectionSeeder extends Seeder
             [
                 'id'                        => 2,
                 'item_id'                   => 85,
-                'inspection_scheduled_date' => '2025/10/05',
+                'inspection_scheduled_date' => '2025-10-05',
                 'inspection_date'           => null,
                 'status'                    => 0,
                 'inspection_person'         => null,
@@ -39,7 +39,7 @@ class InspectionSeeder extends Seeder
             [
                 'id'                        => 3,
                 'item_id'                   => 86,
-                'inspection_scheduled_date' => '2025/10/05',
+                'inspection_scheduled_date' => '2025-10-05',
                 'inspection_date'           => null,
                 'status'                    => 0,
                 'inspection_person'         => null,
@@ -50,7 +50,7 @@ class InspectionSeeder extends Seeder
             [
                 'id'                        => 4,
                 'item_id'                   => 87,
-                'inspection_scheduled_date' => '2025/3/7',
+                'inspection_scheduled_date' => '2025-4-21',
                 'inspection_date'           => null,
                 'status'                    => 0,
                 'inspection_person'         => null,
@@ -61,7 +61,7 @@ class InspectionSeeder extends Seeder
             [
                 'id'                        => 5,
                 'item_id'                   => 89,
-                'inspection_scheduled_date' => '2025/10/20',
+                'inspection_scheduled_date' => '2025-10-20',
                 'inspection_date'           => '2024-10-20',
                 'status'                    => 1,
                 'inspection_person'         => '管理者大川',


### PR DESCRIPTION
## 目的

設定したAmazon EventBridgeルールが正しく動くかどうかチェックするため、
点検・廃棄のシーダーファイルの点検・廃棄予定日を直近の日付に設定すること。

## 関連Issue

- 関連Issue: #321 

## 変更点

- 変更点1
InspectionSeederの1つのデータの点検予定日を「2025/4/21」に設定。

- 変更点2
DisposalSeederの1つのデータの廃棄予定日を「2025/4/20」に設定。

- 変更点3
InspectionSeederの日付の形式が「2025/10/05」のようになっていたので、
すべて「2025-10-05」のような形式に修正。