### PR TITLE
cd:ブラウザ上のGitHubで手動でデプロイ実行を可能に設定

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - '**'
+  workflow_dispatch:
 
 env:
   AWS_REGION: ap-northeast-1
@@ -22,6 +23,10 @@ jobs:
 # Build
   build-and-push:
     if: github.event.pull_request.merged == true
+    # if: |
+    #   github.event.pull_request.merged == true && 
+    #   contains(github.event.pull_request.labels.*.name, 'deploy') &&
+    #   !contains(github.event.pull_request.title, '[skip ci]')
     runs-on: ubuntu-latest
     defaults:
       run:


### PR DESCRIPTION
## 目的

ブラウザ上のGitHubで手動でデプロイ実行を可能に設定。

## 変更点

- 変更点1
cd.ymlに「workflow_dispatch:」を追加しました。
TerraformによるAWSリソースの置き換えが成功しているか確認するため、デプロイを行いやすくしました。
（コメントアウト部分はこれから改善予定。）