### PR TITLE
cd: DBの設定情報をGitHub SecretsからAWS Secrets Managerの値を使用するよう変更

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -48,10 +48,23 @@ jobs:
           echo "APP_PORT=80" >> .env
 
           # DBの設定
-          echo "DB_HOST=${{ secrets.PROD_DB_HOST }}" >> .env 
-          echo "DB_DATABASE=${{ secrets.PROD_DB_DATABASE }}" >> .env
-          echo "DB_USERNAME=${{ secrets.PROD_DB_USERNAME }}" >> .env
-          echo "DB_PASSWORD=${{ secrets.PROD_DB_PASSWORD }}" >> .env
+          # AWSから直接取得
+          SECRET=$(aws secretsmanager get-secret-value \
+            --secret-id portfolio-rds-credentials \ #AWS Secrets Managerのtfファイルで設定したID
+            --region ap-northeast-1 \
+            --query SecretString \
+            --output text)
+          
+          db_host=$(echo $SECRET | jq -r '.host')
+          db_password=$(echo $SECRET | jq -r '.password')
+          db_username=$(echo $SECRET | jq -r '.username')
+          db_database=$(echo $SECRET | jq -r '.database')
+          
+          echo "DB_HOST=$db_host" >> .env
+          echo "DB_PASSWORD=$db_password" >> .env
+          echo "DB_USERNAME=$db_username" >> .env
+          echo "DB_DATABASE=$db_database" >> .env
+          
 
           # セッションの設定
           echo "SESSION_DOMAIN=${{ secrets.PROD_SESSION_DOMAIN }}" >> .env


### PR DESCRIPTION
## 目的

TerraformでDB情報を管理することにより、DB_HOSTやDB_PASSWORDが都度変化することになりました。
よって、DB情報をAWS Secrets Managerに登録し、cd.ymlでそれらの値を取得するよう変更しました。
（AWS Secrets ManagerはTerraformの管理対象です。）

## 変更点


- 変更点1
cd.ymlにおいてGitHub Secretsから取得していた以下の値を、AWS Secrets Managerから取得するようにしました。
-  DB_HOST（Terraformでの生成により変化）
-  DB_PASSWORD（Terraformでの生成により変化）
- DB_USERNAME（固定）
- DB_DATABASE（固定）