### PR TITLE
cd: DB情報設定のコマンドにコメントが混ざっていたのを修正

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -50,7 +50,7 @@ jobs:
           # DBの設定
           # AWSから直接取得
           SECRET=$(aws secretsmanager get-secret-value \
-            --secret-id portfolio-rds-credentials \ #AWS Secrets Managerのtfファイルで設定したID
+            --secret-id portfolio-rds-credentials \
             --region ap-northeast-1 \
             --query SecretString \
             --output text)


### PR DESCRIPTION
## 目的

GitHub Actionsの自動デプロイでエラーが出たので、該当コマンドを修正しました。

## 変更点

- 変更点1
DB情報設定用のコマンドにコメントが混ざっいてたので削除。