### PR TITLE
fix: CloudFrontのS3設定に伴いfilesystems.phpを修正

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -80,6 +80,7 @@ jobs:
           echo "FILESYSTEM_DISK=s3" >> .env
           echo "AWS_DEFAULT_REGION=${{ secrets.PROD_AWS_DEFAULT_REGION }}" >> .env
           echo "AWS_BUCKET=${{ secrets.PROD_AWS_BUCKET }}" >> .env
+          echo "AWS_URL=${{ secrets.PROD_APP_URL }}" >> .env
 
           # ログの設定
           echo "LOG_SLACK_WEBHOOK_URL=${{ secrets.PROD_LOG_SLACK_WEBHOOK_URL }}" >> .env

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -50,7 +50,8 @@ return [
             'secret' => env('AWS_SECRET_ACCESS_KEY'),
             'region' => env('AWS_DEFAULT_REGION'),
             'bucket' => env('AWS_BUCKET'),
-            'url' => env('AWS_URL'),
+            'url' => env('AWS_URL'), // CloudFront URL
+            'root' => 'storage',  // ← S3 内のプレフィックス
             'endpoint' => env('AWS_ENDPOINT'),
             'use_path_style_endpoint' => env('AWS_USE_PATH_STYLE_ENDPOINT', false),
             'throw' => false,


### PR DESCRIPTION
## 目的

CloudFrontのS3のキャッシュ設定に伴い、filesystems.phpの必要箇所を修正しました。

## 変更点


- 変更点1
filesystems.phpに以下を追加。
`
'url' => env('AWS_URL'), // CloudFront URL
 'root' => 'storage',  // ← S3 内のプレフィックス
`

- 変更点2
cd.ymlでfilesytems.phpで使用するAWS_URLの値を注入。
値としては重複しているので、既に存在するGitHub ActionsのSecretsの「PROD_APP_URL」を使用。
`echo "AWS_URL=${{ secrets.PROD_APP_URL }}" >> .env`