### PR TITLE
chore: Dockerfileの依存関係構築にnpm ciを採用

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ RUN curl -sL https://deb.nodesource.com/setup_22.x | bash - \
 
 # 必要なNPMパッケージをインストール
 COPY package*.json ./
-RUN npm install
+RUN npm ci
 
 # AWS CLIのインストール
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \


### PR DESCRIPTION
## 目的

Dockerfileの依存関係構築にnpm ciを採用。

## 変更点

- 変更点1
Dockerfileで確実にnpm run buildが出来るように、依存関係構築コマンドを変更しました。
npm install -> npm ci