### PR TITLE
revert: filesystems.phpのs3のrootの値を削除

### DIFF
--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -51,7 +51,6 @@ return [
             'region' => env('AWS_DEFAULT_REGION'),
             'bucket' => env('AWS_BUCKET'),
             'url' => env('AWS_URL'), // CloudFront URL
-            'root' => 'storage',  // ← S3 内のプレフィックス
             'endpoint' => env('AWS_ENDPOINT'),
             'use_path_style_endpoint' => env('AWS_USE_PATH_STYLE_ENDPOINT', false),
             'throw' => false,


### PR DESCRIPTION
## 目的

CloudFrontのS3の設定に伴い、以前設定したfilesystems.phpのs3のrootの値を元に戻しました。

## 変更点

- 変更点1
filesystems.phpのs3のrootの値を削除しました。