### PR TITLE
refac: cd.ymlとDockerfileをそれぞれの責務に従いリファクタリング

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -35,6 +35,22 @@ jobs:
       # Checkout code
       - uses: actions/checkout@v4
 
+      # 1) Node を用意
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'npm'
+
+      # 2) Vite用の環境変数（必要なら）を付与してビルド
+      - name: Build front (Vite)
+        env:
+          VITE_APP_URL: ${{ secrets.PROD_VITE_APP_URL }}
+          VITE_API_BASE_URL: ${{ secrets.PROD_VITE_API_BASE_URL }}
+        run: |
+          npm ci
+          npm run build
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -47,12 +63,14 @@ jobs:
           cp .env.example .env
           
           # APPの設定
-          # APP_KEYは、イメージビルド時に「php artisan key:generate」を行う
           echo "APP_NAME=EMS" >> .env
           echo "APP_ENV=production" >> .env
           echo "APP_DEBUG=false" >> .env
           echo "APP_URL=${{ secrets.PROD_APP_URL }}" >> .env
           echo "APP_PORT=80" >> .env
+
+          # アプリケーションキーを注入
+          echo "APP_KEY=${{ secrets.PROD_APP_KEY }}" >> .env
 
           # DBの設定
           # AWSから直接取得
@@ -81,6 +99,7 @@ jobs:
           echo "AWS_DEFAULT_REGION=${{ secrets.PROD_AWS_DEFAULT_REGION }}" >> .env
           echo "AWS_BUCKET=${{ secrets.PROD_AWS_BUCKET }}" >> .env
           echo "AWS_URL=${{ secrets.PROD_APP_URL }}" >> .env
+          echo "S3_BUCKET_URL=${{ secrets.PROD_S3_BUCKET_URL }}" >> .env
 
           # ログの設定
           echo "LOG_SLACK_WEBHOOK_URL=${{ secrets.PROD_LOG_SLACK_WEBHOOK_URL }}" >> .env
@@ -91,9 +110,6 @@ jobs:
 
           # SANCTUMの設定
           echo "SANCTUM_STATEFUL_DOMAINS=${{ secrets.PROD_SANCTUM_STATEFUL_DOMAINS }}" >> .env
-
-          # s3
-          echo "S3_BUCKET_URL=${{ secrets.PROD_S3_BUCKET_URL }}" >> .env
 
           # Userパスワード
           echo "GUEST_PASSWORD=${{ secrets.PROD_GUEST_PASSWORD }}" >> .env

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,16 +47,6 @@ RUN docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp --with-x
 RUN curl -sL https://deb.nodesource.com/setup_22.x | bash - \
     && apt-get install -y nodejs
 
-# 必要なNPMパッケージをインストール
-COPY package*.json ./
-RUN npm ci
-
-# AWS CLIのインストール
-RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
-    && unzip awscliv2.zip \
-    && ./aws/install \
-    && rm -rf awscliv2.zip aws
-
 # Apacheのmod_rewriteを有効化
 RUN a2enmod rewrite
 
@@ -67,13 +57,7 @@ COPY ./docker-config/apache2.conf /etc/apache2/sites-available/000-default.conf
 COPY . /var/www/html
 
 # Composerの依存関係をインストール
-RUN composer install
-
-# アプリケーションキーの生成
-RUN php artisan key:generate
-
-# アプリケーションのビルド
-RUN npm run build
+RUN composer install --no-dev --optimize-autoloader --no-interaction --prefer-dist
 
 # ログディレクトリの所有者と権限を設定 
 RUN chown -R www-data:www-data /var/www/html/storage \


### PR DESCRIPTION
## 目的

cd.ymlとDockerfileをそれぞれの責務に従いリファクタリング。

## 変更点

- 変更点1
npm ci, npm run buildをDockerfileではなく、GitHub Actionsのcd.ymlで行うよう修正。

- 変更点2
composer installを本番向けの軽量版のコマンドへ修正。
->composer install --no-dev --optimize-autoloader --no-interaction --prefer-dist

- 変更点3
php artisan key:generateのキー生成をDockerfileで毎度行っていたので、
cd.yml上でGitHub Secretsから.envに注入するように変更。
GitHub SecretsにはPROD_APP_KEYを設定済み。