### PR TITLE
refac: 自動デプロイのnpm ciでのエラー防止のためimportを修正

### DIFF
--- a/resources/js/app.ts
+++ b/resources/js/app.ts
@@ -3,11 +3,12 @@ import './micromodal';
 import '../css/app.css';
 import '../css/micromodal.css';
 
-import type { App, DefineComponent } from "vue"; 
+import type { App, DefineComponent } from "vue";
 import { createApp, h } from 'vue';
+
+import { ZiggyVue } from 'ziggy-js'
 import { createInertiaApp } from '@inertiajs/vue3';
 import { resolvePageComponent } from 'laravel-vite-plugin/inertia-helpers';
-import { ZiggyVue } from '../../vendor/tightenco/ziggy/src/js';
 
 const appName = import.meta.env.VITE_APP_NAME || 'Laravel';
 


### PR DESCRIPTION
## 目的

自動デプロイのnpm ciでのエラー防止のためimportを修正。

## 変更点

このセクションでは、具体的な変更点や修正箇所を箇条書きでリストアップしてください。

- 変更点1
app.tsのziggyのimportがLaravel側のファイルに依存していたので、
直接npmに依存するように修正しました。
理由は自動デプロイでこの部分の依存関係のエラーが発生したためです。
