### PR TITLE
cd: CloudFrontのS3設定のため、S3にViteのbuildファイルをアップロード

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -35,14 +35,12 @@ jobs:
       # Checkout code
       - uses: actions/checkout@v4
 
-      # 1) Node を用意
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: 'npm'
 
-      # 2) Vite用の環境変数（必要なら）を付与してビルド
       - name: Build front (Vite)
         env:
           VITE_APP_URL: ${{ secrets.PROD_VITE_APP_URL }}
@@ -57,6 +55,37 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.AWS_REGION }}
+
+      # ビルド資産を S3 へアップ（長期キャッシュ）
+      # CloudFront 側は origin_path=/storage、/build/* を S3 オリジンへ振る前提
+      - name: Sync Vite assets to S3 (long cache)
+        run: |
+          aws s3 sync public/build/assets \
+            s3://${{ secrets.PROD_AWS_BUCKET }}/storage/build/assets \
+            --delete \
+            --cache-control "public,max-age=31536000,immutable"
+
+      # manifest.json は短期キャッシュで個別アップ
+      - name: Upload manifest.json (short cache)
+        run: |
+          aws s3 cp public/build/manifest.json \
+            s3://${{ secrets.PROD_AWS_BUCKET }}/storage/build/manifest.json \
+            --cache-control "public,max-age=300"
+
+      # Terraformでdistribution IDは毎度変化するのでAWS CLIで取得
+      - name: Resolve CloudFront distribution ID by alias
+        run: |
+          CF_ID=$(aws cloudfront list-distributions \
+            --query "DistributionList.Items[?contains(Aliases.Items || \`[]\`, 'itemnavi.biz')].Id | [0]" \
+            --output text)
+          echo "CF_DIST_ID=$CF_ID" >> $GITHUB_ENV
+
+      # manifest だけキャッシュ無効化
+      - name: Invalidate manifest
+        run: |
+          aws cloudfront create-invalidation \
+            --distribution-id ${{ env.CF_DIST_ID }} \
+            --paths "/build/manifest.json"
 
       - name: Create .env file
         run: |


### PR DESCRIPTION
## 目的

CloudFrontのS3設定のため、S3にViteのbuildファイルをアップロード。

## 変更点

- 変更点1
S3バケットにcd.yml上で作成したViteのbuildファイルをアップロードしました。

- 変更点2
manifest.jsonは個別でアップロードして、キャッシュを削除しました。
（※manifest.json以外のbuildファイル名は毎度異なるハッシュ値になるため。）