### PR TITLE
cd: S3へのViteのbuildファイルのアップロードコマンドを修正

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -60,8 +60,7 @@ jobs:
       # CloudFront 側は origin_path=/storage、/build/* を S3 オリジンへ振る前提
       - name: Sync Vite assets to S3 (long cache)
         run: |
-          aws s3 sync public/build/assets \
-            s3://${{ secrets.PROD_AWS_BUCKET }}/storage/build/assets \
+          aws s3 sync "public/build/assets" "s3://${{ secrets.PROD_AWS_BUCKET }}/storage/build/assets" \
             --delete \
             --cache-control "public,max-age=31536000,immutable"
 


### PR DESCRIPTION
## 目的

S3へのViteのbuildファイルのアップロードコマンドを修正。

## 変更点

このセクションでは、具体的な変更点や修正箇所を箇条書きでリストアップしてください。

- 変更点1
AWS CLIのaws s3 syncコマンドの""（ダブルクォーテーション）が抜けていたので追加。