### PR TITLE
cd: favicon.icoをS3にアップロードするコマンドを追加

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -71,6 +71,12 @@ jobs:
             s3://${{ secrets.PROD_AWS_BUCKET }}/storage/build/manifest.json \
             --cache-control "public,max-age=300"
 
+      - name: Upload favicon
+        run: |
+          aws s3 cp public/favicon.ico \
+            s3://${{ secrets.PROD_AWS_BUCKET }}/storage/favicon.ico \
+            --cache-control "public,max-age=86400"
+
       # Terraformでdistribution IDは毎度変化するのでAWS CLIで取得
       - name: Resolve CloudFront distribution ID by alias
         run: |


### PR DESCRIPTION
## 目的

favicon.icoをS3にアップロードするコマンドを追加。

## 変更点

- 変更点1
AWC CLIでS3にfavicon.icoをアップロードするコマンドを追加。
理由はCloudFrontを介したアプリ画面へのアクセスで、facivon.icoが取得できず504エラーが出たため。