### PR TITLE
fix: CloudFrontのTrustProxiesの設定を修正

### DIFF
--- a/app/Http/Middleware/TrustProxies.php
+++ b/app/Http/Middleware/TrustProxies.php
@@ -12,7 +12,7 @@ class TrustProxies extends Middleware
      *
      * @var array<int, string>|string|null
      */
-    protected $proxies;
+    protected $proxies = '*';
 
     /**
      * The headers that should be used to detect proxies.

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -38,7 +38,6 @@ class AppServiceProvider extends ServiceProvider
         // 本番環境でURLをHTTPSに強制する
         if ($this->app->environment('production')) {
             URL::forceScheme('https');
-            $this->app['request']->server->set('HTTPS', 'on');
         }
     }
 }


### PR DESCRIPTION
## 目的

CloudFrontのTrustProxiesの設定を修正

## 変更点

- 変更点1
TrustProxies.phpでプロキシを信用するように設定。

- 変更点2
AppServiceProvider.phpの重複した無駄な設定を削除。