### PR TITLE
revert: TrustProxiesの設定を確認のため元に戻す

### DIFF
--- a/app/Http/Middleware/TrustProxies.php
+++ b/app/Http/Middleware/TrustProxies.php
@@ -12,7 +12,7 @@ class TrustProxies extends Middleware
      *
      * @var array<int, string>|string|null
      */
-    protected $proxies = '*';
+    protected $proxies;
 
     /**
      * The headers that should be used to detect proxies.


### PR DESCRIPTION
## 目的

本番環境のアプリの動作確認のため、TrustProxiesの設定を元に戻す。

## 変更点

このセクションでは、具体的な変更点や修正箇所を箇条書きでリストアップしてください。

- 変更点1
プロキシを信頼しないように設定しました。
