### PR TITLE
revert: 本番環境のアプリの動作検証のためAppServiceProviderの設定を元に戻す

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -38,6 +38,7 @@ class AppServiceProvider extends ServiceProvider
         // 本番環境でURLをHTTPSに強制する
         if ($this->app->environment('production')) {
             URL::forceScheme('https');
+            $this->app['request']->server->set('HTTPS', 'on');
         }
     }
 }


### PR DESCRIPTION
## 目的

本番環境のアプリの動作検証のためAppServiceProviderの設定を元に戻す。

## 変更点

このセクションでは、具体的な変更点や修正箇所を箇条書きでリストアップしてください。

- 変更点1
AppServiceProviderの設定を元に戻しました。
理由は、ALBに直接アクセス時のCORSエラーが消えないので、動作を検証するため。