### PR TITLE
revert:#505 本番環境で上手くいかなかったので、セッション認証からSanctumへ元の状態に戻す

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -23,49 +23,49 @@ use Illuminate\Support\Facades\Route;
 */
 
 // 備品の廃棄
-Route::middleware(['auth', 'verified', 'can:staff-higher'])
+Route::middleware(['auth:sanctum:', 'verified', 'can:staff-higher'])
   ->post('/items/{id}/restore', [ItemController::class, 'restore'])
   ->name('api.items.restore');
 
 // 対象の備品の編集履歴を取得する
-Route::middleware(['auth', 'verified', 'can:staff-higher'])
+Route::middleware(['auth:sanctum:', 'verified', 'can:staff-higher'])
   ->get('/edithistory', [EdithistoryController::class, 'index']);
 
 // 在庫数の入出庫履歴を取得する
-Route::middleware('auth', 'verified', 'can:user-higher')
+Route::middleware('auth:sanctum:', 'verified', 'can:user-higher')
   ->get('/stock_transactions', [StockTransactionController::class, 'index'])
   ->name('stock_transactions');
 
 // 消耗品の入出・出庫モーダルで更新処理をした際、在庫数をリアルタイムに反映する
-Route::middleware(['auth', 'verified', 'can:staff-higher'])
+Route::middleware(['auth:sanctum:', 'verified', 'can:staff-higher'])
   ->get('/consumable_items/{itemId}/stock', [UpdateStockController::class, 'getStock']);
 
 // 通知を表示したら既読にする
-Route::middleware(['auth', 'verified', 'can:staff-higher'])->group(function () {
+Route::middleware(['auth:sanctum:', 'verified', 'can:staff-higher'])->group(function () {
   Route::patch('/notifications/{id}/read', [NotificationController::class, 'markAsRead']);
 });
 
 // ベルに未読通知数を表示する
-Route::middleware('auth', 'verified', 'can:staff-higher')
+Route::middleware('auth:sanctum:', 'verified', 'can:staff-higher')
   ->get('/notifications_count', function () {
-    return auth()->user()->unreadNotifications;
+    return auth:sanctum:()->user()->unreadNotifications;
   });
 
 // リクエストのステータスのプルダウンを変更する
-Route::middleware(['auth', 'verified', 'can:staff-higher', 'RestrictGuestAccess'])
+Route::middleware(['auth:sanctum:', 'verified', 'can:staff-higher', 'RestrictGuestAccess'])
   ->post('item-requests/{id}/update-status', [ItemRequestController::class, 'updateStatus'])
   ->name('item-requests.update-status');
 
 // リクエスト一覧画面でユーザーの権限情報を取得する
-Route::middleware(['auth', 'verified', 'can:user-higher'])
+Route::middleware(['auth:sanctum:', 'verified', 'can:user-higher'])
   ->get('/user-role', function (Request $request) {
-    return auth()->user()->role;
+    return auth:sanctum:()->user()->role;
   });
 
 // AuthenticatedLayout.vueのプロフィール画像URLを取得する
-Route::middleware(['auth', 'verified', 'can:user-higher'])
+Route::middleware(['auth:sanctum:', 'verified', 'can:user-higher'])
   ->get('/profile-image', [ProfileController::class, 'getProfileImage']);
 
 // Vue側のエラーをAPIでログに書き込む
-Route::middleware(['auth', 'verified', 'can:user-higher'])
+Route::middleware(['auth:sanctum:', 'verified', 'can:user-higher'])
   ->post('/log-error', [VueErrorController::class, 'logError']);


### PR DESCRIPTION
## 目的

本番環境で504エラーが解消されなかったため、セッション認証からSanctumへ元の状態に戻す。

## 関連Issue

- 関連Issue: #505 

## 変更点

- 変更点1
routes/api.phpの「auth」を「auth:sanctum」へすべて修正しました。