### PR TITLE
fix:#505 ヘルスチェックのルートがセッションを作成しないよう修正

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -112,6 +112,9 @@ Route::middleware(['auth', 'verified', 'can:user-higher'])->group(function () {
 // AWSのターゲットグループのヘルスチェック用
 Route::get('/health-check', function () {
     return response()->json(['status' => 'OK']);
-});
+})->withoutMiddleware([
+    \Illuminate\Session\Middleware\StartSession::class,
+    \App\Http\Middleware\VerifyCsrfToken::class,
+]);
 
 require __DIR__ . '/auth.php';


### PR DESCRIPTION
## 目的

本番環境DBのSessionテーブルに、ヘルスチェックルートの不要なセッションレコードが大量に生成されていました。
これらがアプリの正常動作を妨げていたので、ヘルスチェックルートではセッションを作成しないように修正しました。

## 関連Issue

- 関連Issue: #123

## 変更点

このセクションでは、具体的な変更点や修正箇所を箇条書きでリストアップしてください。

- 変更点1
「/health-check」のルートでは以下のミドルウェアを使用しないように修正しました。
 \Illuminate\Session\Middleware\StartSession::class,
   \App\Http\Middleware\VerifyCsrfToken::class,
