### PR TITLE
fix:#505 ヘルスチェックのルートのすべてのミドルウェアを無効化

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -112,9 +112,6 @@ Route::middleware(['auth', 'verified', 'can:user-higher'])->group(function () {
 // AWSのターゲットグループのヘルスチェック用
 Route::get('/health-check', function () {
     return response()->json(['status' => 'OK']);
-})->withoutMiddleware([
-    \Illuminate\Session\Middleware\StartSession::class,
-    \App\Http\Middleware\VerifyCsrfToken::class,
-]);
+})->withoutMiddleware([]);
 
 require __DIR__ . '/auth.php';


### PR DESCRIPTION
## 目的

ELBによるECSコンテナ内のヘルスチェックが500エラーで失敗するようになりました。
ミドルウェアが干渉していることが原因と仮説を立て、
ヘルスチェックのルートのすべてのミドルウェアを無効化しました。

## 関連Issue

- 関連Issue: #505

## 変更点

- 変更点1
web.phpの「/health-check」ルートのすべてのミドルウェアを無効化するよう修正しました。