### PR TITLE
fix:#505 自動デプロイ中、S3バケット直下にbuildファイルをコピーするように修正

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -60,7 +60,7 @@ jobs:
       # CloudFront 側は origin_path=/storage、/build/* を S3 オリジンへ振る前提
       - name: Sync Vite assets to S3 (long cache)
         run: |
-          aws s3 sync "public/build/assets" "s3://${{ secrets.PROD_AWS_BUCKET }}/storage/build/assets" \
+          aws s3 sync "public/build/assets" "s3://${{ secrets.PROD_AWS_BUCKET }}/build/assets" \
             --delete \
             --cache-control "public,max-age=31536000,immutable"
 
@@ -68,7 +68,7 @@ jobs:
       - name: Upload manifest.json (short cache)
         run: |
           aws s3 cp public/build/manifest.json \
-            s3://${{ secrets.PROD_AWS_BUCKET }}/storage/build/manifest.json \
+            s3://${{ secrets.PROD_AWS_BUCKET }}/build/manifest.json \
             --cache-control "public,max-age=300"
             
       # favicon.icoをアップ


### PR DESCRIPTION
## 目的

CloudFront側のS3の「origin_path="/storage"」を削除したため、
Vuebuildファイルはstorage直下ではなくS3のバケット直下に存在しなければならなくなりました。
よって、自動デプロイ中にbuildファイルはS3のバケット直下にコピーするよう修正しました。

## 関連Issue

- 関連Issue: #505

## 変更点

- 変更点1
「npm run build」で生成したbuildファイルをS3直下にコピーするようパスを修正しました。