### PR TITLE
fix:#505 以前動作確認のために作った不要なミドルウェアを削除

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace App\Http;
 
 use Illuminate\Foundation\Http\Kernel as HttpKernel;
@@ -44,7 +45,6 @@ class Kernel extends HttpKernel
             \Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful::class,
             \Illuminate\Routing\Middleware\ThrottleRequests::class . ':api',
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
-            \App\Http\Middleware\LogRequestDetails::class,
         ],
     ];
 


### PR DESCRIPTION
## 目的

504エラーの原因となっている可能性のある不要なミドルウェアを削除しました。
これは以前セッションの動作を確認するために作成したものでした。

## 関連Issue

- 関連Issue: #505

## 変更点

- 変更点1
Kernel.phpの不要なミドルウェア「\App\Http\Middleware\LogRequestDetails::class」を削除しました。