### PR TITLE
fix:#505 自動デプロイでfacivonを配置するS3上の場所を変更

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Upload favicon
         run: |
           aws s3 cp public/favicon.ico \
-            s3://${{ secrets.PROD_AWS_BUCKET }}/storage/favicon.ico \
+            s3://${{ secrets.PROD_AWS_BUCKET }}/favicon.ico \
             --cache-control "public,max-age=86400"
 
       # Terraformでdistribution IDは毎度変化するのでAWS CLIで取得


### PR DESCRIPTION
## 目的

CloudFrontのパスパターンの設定を変更したため、自動デプロイでfacivonはS3上の直下に配置するよう修正しました。

## 関連Issue

- 関連Issue: #505

## 変更点

- 変更点1
cd.ymlでfavicon.icoをコピーするS3上のパスを変更しました。