### PR TITLE
fix:#518 シェルスクリプトのS3画像同期のフラグ判定を削除

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -8,25 +8,14 @@ echo "======================================"
 echo "Container starting..."
 echo "======================================"
 
-# S3から画像をダウンロード（初回のみ）
-if [ ! -f /var/www/html/storage/app/public/.downloaded ]; then
-    echo "Downloading images from S3..."
-    
-    # ECSタスクロールの認証情報を自動的に使用
-    # 環境変数（AWS_ACCESS_KEY_ID等）の設定は不要
-    aws s3 sync s3://bucket-portfolio-ems/storage/app/public/ \
-        /var/www/html/storage/app/public/ \
-        --exclude ".gitkeep" \
-        --exclude ".downloaded" \
-        || echo "Warning: Failed to download images from S3 (this is normal in local development)"
-    
-    # ダウンロード完了フラグを作成
-    touch /var/www/html/storage/app/public/.downloaded
-    
-    echo "✓ Images downloaded successfully"
-else
-    echo "✓ Images already exist, skipping download"
-fi
+# S3から画像を同期
+echo "Syncing images from S3..."
+aws s3 sync s3://bucket-portfolio-ems/storage/app/public/ \
+    /var/www/html/storage/app/public/ \
+    --exclude ".gitkeep" \
+    || echo "Warning: Failed to sync images from S3 (this is normal in local development)"
+
+echo "✓ Images synced"
 
 # シンボリックリンクを作成
 echo "Creating storage symlink..."


### PR DESCRIPTION
## 目的

シェルスクリプトのS3画像同期のフラグ判定を削除。

## 関連Issue

- 関連Issue: #518 

## 変更点

- 変更点1
「.downloaded」ファイルでフラグ判定していましたが、
①状況が複雑になるため判断が難しくなる
②aws s3 syncコマンドは差分を同期するのでフラグ判定は必要ない
以上の理由でフラグ判定部分を削除しました。