### PR TITLE
fix:#518 ダウンロード元のS3バケット側のパスが間違っていたので修正

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -10,7 +10,7 @@ echo "======================================"
 
 # S3から画像を同期
 echo "Syncing images from S3..."
-aws s3 sync s3://bucket-portfolio-ems/storage/app/public/ \
+aws s3 sync s3://bucket-portfolio-ems/ \
     /var/www/html/storage/app/public/ \
     --exclude ".gitkeep" \
     || echo "Warning: Failed to sync images from S3 (this is normal in local development)"


### PR DESCRIPTION
## 目的

ダウンロード元のS3バケット側のパスが間違っていたので修正。

## 関連Issue

- 関連Issue: #123

## 変更点

- 変更点1
ダウンロード元のS3バケットのパスが、存在しない誤ったものになっていたので正しいパスに修正しました。