### PR TITLE
fix:#505 プロフィール画像URL取得時のstorageの設定を修正

### DIFF
--- a/app/Http/Controllers/Api/ProfileController.php
+++ b/app/Http/Controllers/Api/ProfileController.php
@@ -13,9 +13,8 @@ class ProfileController extends Controller
         $user = Auth::user();
         return response()->json([
             'profile_image_url' => $user->profile_image
-                ? Storage::disk('s3')->url('profile/' . $user->profile_image)
-                : Storage::disk('s3')->url('profile/profile_default_image.png'),
+                ? Storage::disk()->url('profile/' . $user->profile_image)
+                : Storage::disk()->url('profile/profile_default_image.png'),
         ]);
     }
 }
-


### PR DESCRIPTION
## 目的

プロフィール画像URL取得のためのAPIで500エラーが出ていました。
確認してみるとStorageの設定がS3に対してのみになっていたので、
現在のECSコンテナ内（public）に対応するよう修正しました。

## 関連Issue

- 関連Issue: #518 

## 変更点

- 変更点1
Storage::disk('s3')をStorage::disk()に修正しました。
Storage::disk()は「public」も「s3」も切り替え可能な柔軟な書き方となります。