### PR TITLE
cd:#442 プルリクエスト時にdeployラベルを付けるか、タイトルに[deploy]をつけないと自動デプロイ出来ないよう設定する

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -22,11 +22,10 @@ permissions:
 jobs:
 # Build
   build-and-push:
-    if: github.event.pull_request.merged == true
-    # if: |
-    #   github.event.pull_request.merged == true && 
-    #   contains(github.event.pull_request.labels.*.name, 'deploy') &&
-    #   !contains(github.event.pull_request.title, '[skip ci]')
+    if: |
+      github.event.pull_request.merged == true && 
+      (contains(github.event.pull_request.labels.*.name, 'deploy') ||
+       contains(github.event.pull_request.title, '[deploy]'))
     runs-on: ubuntu-latest
     defaults:
       run:


### PR DESCRIPTION
## 目的

プルリクエスト時にdeployラベルを付けるか、タイトルに[deploy]をつけないと自動デプロイ出来ないよう設定する

## 関連Issue

- 関連Issue: #442

## 変更点

このセクションでは、具体的な変更点や修正箇所を箇条書きでリストアップしてください。

- 変更点1
以下のどちらかの条件を満たすと自動デプロイするように変更しました。
①プルリクエスト作成時、「deploy」ラベルを付ける
②プルリクエストのタイトルに[deploy]の文言を含める