### PR TITLE
fix: Viteビルド前にcomposer installを追加(Ziggy依存解決)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -41,6 +41,14 @@ jobs:
           node-version: 22
           cache: 'npm'
 
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+
+      - name: Install Composer dependencies
+        run: composer install --no-dev --optimize-autoloader --no-interaction
+
       - name: Build front (Vite)
         env:
           VITE_APP_URL: ${{ secrets.PROD_VITE_APP_URL }}


### PR DESCRIPTION
## 目的

Laravel11へアップグレードしたアプリのデプロイに失敗しました。

## 関連Issue

- 関連Issue: #567

## 変更点

- 変更点1
cd.ymlのViteでビルドする前に、「composer install」を追加しました。
理由としてはLaravel11ではZiggyがnpm依存ではなくcomposer依存になったため、参照先が存在せずデプロイが失敗したからです。