### PR TITLE
fix: wkhtmltopdfを0.12.6に固定してPDF生成機能を修正

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,11 +32,11 @@ RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2
     && ./aws/install \
     && rm -rf aws awscliv2.zip
 
-# wkhtmltopdf 0.12.5 を明示的にインストール（バージョン固定）
+# wkhtmltopdf 0.12.6 を明示的にインストール（バージョン固定）
 # apt-getではなくGitHubから直接ダウンロードして確実性を担保
-RUN wget https://github.com/wkhtmltopdf/packaging/releases/download/0.12.5-1/wkhtmltox_0.12.5-1.buster_amd64.deb \
-    && dpkg -i wkhtmltox_0.12.5-1.buster_amd64.deb || apt-get install -fy \
-    && rm wkhtmltox_0.12.5-1.buster_amd64.deb \
+RUN wget https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-1/wkhtmltox_0.12.6-1.buster_amd64.deb \
+    && dpkg -i wkhtmltox_0.12.6-1.buster_amd64.deb || apt-get install -fy \
+    && rm wkhtmltox_0.12.6-1.buster_amd64.deb \
     && wkhtmltopdf --version  # ビルド時にバージョンを確認
 
 # GDライブラリの設定とインストール

--- a/config/snappy.php
+++ b/config/snappy.php
@@ -35,7 +35,7 @@ return [
 
     'pdf' => [
         'enabled' => true,
-        'binary' => env('WKHTMLTOPDF_BINARY', '/usr/bin/wkhtmltopdf'),
+        'binary' => env('WKHTMLTOPDF_BINARY', '/usr/local/bin/wkhtmltopdf'),
         'timeout' => false,
         'options' => [],
         'env'     => [],


### PR DESCRIPTION
## 目的

GitHub Actionsによる自動デプロイ時にwkhtmltopdf0.12.5はダウンロードできず失敗しました。
wkhtmltopdfをダウンロード可能な0.12.6に固定して、デプロイを実行できるように修正しました。

## 関連Issue

- 関連Issue: #567

## 変更点

- 変更点1
Dockerfileでwkhtmltopdfの0.12.6をダウンロードするようコマンドを修正しました。

- 変更点2
config/snappy.phpのパスを「'/usr/local/bin/wkhtmltopdf'」に修正しました。
「wget」と「dpkg」のコマンドでインストールする場合、インストールされるwkhtmltopdf'ファイルのパスは、
「'/usr/bin/wkhtmltopdf'」ではなく「'/usr/local/bin/wkhtmltopdf'」になるためです。