### PR TITLE
Chore/upgrade inertia v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "guzzlehttp/guzzle": "^7.8",
         "hikaeme/monolog-ltsv-formatter": "^3.0",
         "illuminate/filesystem": "*",
-        "inertiajs/inertia-laravel": "^1.0",
+        "inertiajs/inertia-laravel": "^2.0",
         "intervention/image": "^3.0",
         "jenssegers/agent": "^2.6",
         "laravel/framework": "^12.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "210600c8f0b8956509fba813ce1ea27e",
+    "content-hash": "8cb2fec9128e3210a2958a1ae6346931",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -1748,28 +1748,35 @@
         },
         {
             "name": "inertiajs/inertia-laravel",
-            "version": "v1.3.4",
+            "version": "v2.0.24",
             "source": {
                 "type": "git",
                 "url": "https://github.com/inertiajs/inertia-laravel.git",
-                "reference": "8d52a6753bead9b01a699d40bd142a72668c2a11"
+                "reference": "ea345adad12f110edbbc4bef03b69c2374a535d4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/inertiajs/inertia-laravel/zipball/8d52a6753bead9b01a699d40bd142a72668c2a11",
-                "reference": "8d52a6753bead9b01a699d40bd142a72668c2a11",
+                "url": "https://api.github.com/repos/inertiajs/inertia-laravel/zipball/ea345adad12f110edbbc4bef03b69c2374a535d4",
+                "reference": "ea345adad12f110edbbc4bef03b69c2374a535d4",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "laravel/framework": "^8.74|^9.0|^10.0|^11.0|^12.0",
-                "php": "^7.3|~8.0.0|~8.1.0|~8.2.0|~8.3.0|~8.4.0",
-                "symfony/console": "^5.3|^6.0|^7.0"
+                "laravel/framework": "^10.0|^11.0|^12.0|^13.0",
+                "php": "^8.1.0",
+                "symfony/console": "^6.2|^7.0|^8.0"
+            },
+            "conflict": {
+                "laravel/boost": "<2.2.0"
             },
             "require-dev": {
+                "guzzlehttp/guzzle": "^7.2",
+                "larastan/larastan": "^3.0",
+                "laravel/pint": "^1.16",
                 "mockery/mockery": "^1.3.3",
-                "orchestra/testbench": "^6.45|^7.44|^8.25|^9.3|^10.0",
-                "phpunit/phpunit": "^8.0|^9.5.8|^10.4|^11.5"
+                "orchestra/testbench": "^8.0|^9.2|^10.0|^11.0",
+                "phpunit/phpunit": "^10.4|^11.5|^12.0",
+                "roave/security-advisories": "dev-master"
             },
             "suggest": {
                 "ext-pcntl": "Recommended when running the Inertia SSR server via the `inertia:start-ssr` artisan command."
@@ -1780,9 +1787,6 @@
                     "providers": [
                         "Inertia\\ServiceProvider"
                     ]
-                },
-                "branch-alias": {
-                    "dev-master": "1.x-dev"
                 }
             },
             "autoload": {
@@ -1811,9 +1815,9 @@
             ],
             "support": {
                 "issues": "https://github.com/inertiajs/inertia-laravel/issues",
-                "source": "https://github.com/inertiajs/inertia-laravel/tree/v1.3.4"
+                "source": "https://github.com/inertiajs/inertia-laravel/tree/v2.0.24"
             },
-            "time": "2025-12-15T14:57:37+00:00"
+            "time": "2026-04-10T14:36:44+00:00"
         },
         {
             "name": "intervention/gif",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
             },
             "devDependencies": {
                 "@babel/preset-env": "^7.24.7",
-                "@inertiajs/vue3": "^1.0.0",
+                "@inertiajs/vue3": "^3.0.3",
                 "@tailwindcss/forms": "^0.5.3",
                 "@types/dompurify": "^3.0.5",
                 "@types/micromodal": "^0.3.5",
@@ -2339,28 +2339,35 @@
             }
         },
         "node_modules/@inertiajs/core": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/@inertiajs/core/-/core-1.3.0.tgz",
-            "integrity": "sha512-TJ8R1eUYY473m9DaKlCPRdHTdznFWTDuy5VvEzXg3t/hohbDQedLj46yn/uAqziJPEUZJrSftZzPI2NMzL9tQA==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@inertiajs/core/-/core-3.0.3.tgz",
+            "integrity": "sha512-/4sW/cfNpvujjVOZlB5UNypLGNySs7X7V8IMLNSK8+3j1KsUYGS5wpLd9EqAu8wy8RiW7PPra2rPwB6Lx/ACow==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "axios": "^1.6.0",
-                "deepmerge": "^4.0.0",
-                "nprogress": "^0.2.0",
-                "qs": "^6.9.0"
+                "@jridgewell/trace-mapping": "^0.3.31",
+                "es-toolkit": "^1.33.0",
+                "laravel-precognition": "^2.0.0"
+            },
+            "peerDependencies": {
+                "axios": "^1.13.2"
+            },
+            "peerDependenciesMeta": {
+                "axios": {
+                    "optional": true
+                }
             }
         },
         "node_modules/@inertiajs/vue3": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/@inertiajs/vue3/-/vue3-1.3.0.tgz",
-            "integrity": "sha512-GizqdCM3u4JWunit3uUbW4fEmTLKQTi1W7VvPRdrNy8XDt4Qy2cCmfFjq+aH5tHBSS3fI/ngYuhN7XvwqNaKvw==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@inertiajs/vue3/-/vue3-3.0.3.tgz",
+            "integrity": "sha512-bhJN+GS66g1tYH1p6flKkG1N8oaT5J7ZLqBkavN9mHC6bVfoQCUG6sCuA07WTDfo9tDaxU89wsSSAf4mhn3SuA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@inertiajs/core": "1.3.0",
-                "lodash.clonedeep": "^4.5.0",
-                "lodash.isequal": "^4.5.0"
+                "@inertiajs/core": "3.0.3",
+                "es-toolkit": "^1.33.0",
+                "laravel-precognition": "^2.0.0"
             },
             "peerDependencies": {
                 "vue": "^3.0.0"
@@ -2426,9 +2433,9 @@
             "license": "MIT"
         },
         "node_modules/@jridgewell/trace-mapping": {
-            "version": "0.3.25",
-            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
-            "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+            "version": "0.3.31",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+            "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4704,16 +4711,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/deepmerge": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
-            "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/define-data-property": {
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
@@ -5056,6 +5053,17 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
+        },
+        "node_modules/es-toolkit": {
+            "version": "1.46.0",
+            "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.46.0.tgz",
+            "integrity": "sha512-IToJ6ct9OLl5zz6WsC/1vZEwfSZ7Myil+ygl5Tf30Xjn9AEkzNB4kqp2G7VUJKF1DtTx/ra5M5KLlXvzOg51BA==",
+            "dev": true,
+            "license": "MIT",
+            "workspaces": [
+                "docs",
+                "benchmarks"
+            ]
         },
         "node_modules/esbuild": {
             "version": "0.25.1",
@@ -6647,6 +6655,24 @@
                 "json-buffer": "3.0.1"
             }
         },
+        "node_modules/laravel-precognition": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/laravel-precognition/-/laravel-precognition-2.0.0.tgz",
+            "integrity": "sha512-dmA4HGc9m+TsVNsJs9/XQBI8u6j7coilN+qKkBuhuXQzH3HypwS/c5dFQ4UqUGjBbcxIM7zdk91kM/SRZwIvWQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "es-toolkit": "^1.32.0"
+            },
+            "peerDependencies": {
+                "axios": "^1.4.0"
+            },
+            "peerDependenciesMeta": {
+                "axios": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/laravel-vite-plugin": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/laravel-vite-plugin/-/laravel-vite-plugin-1.2.0.tgz",
@@ -6730,25 +6756,10 @@
             "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
             "license": "MIT"
         },
-        "node_modules/lodash.clonedeep": {
-            "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-            "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/lodash.debounce": {
             "version": "4.0.8",
             "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
             "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/lodash.isequal": {
-            "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-            "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
-            "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
             "dev": true,
             "license": "MIT"
         },
@@ -7004,13 +7015,6 @@
             "engines": {
                 "node": ">=0.10.0"
             }
-        },
-        "node_modules/nprogress": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/nprogress/-/nprogress-0.2.0.tgz",
-            "integrity": "sha512-I19aIingLgR1fmhftnbWWO3dXc0hSxqHQHQb3H8m+K3TnEn/iSeTZZOyvKXWqQESMwuUVnatlCnZdLBZZt2VSA==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/nth-check": {
             "version": "2.1.1",
@@ -7536,22 +7540,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=6"
-            }
-        },
-        "node_modules/qs": {
-            "version": "6.14.0",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-            "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "side-channel": "^1.1.0"
-            },
-            "engines": {
-                "node": ">=0.6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/queue-microtask": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     },
     "devDependencies": {
         "@babel/preset-env": "^7.24.7",
-        "@inertiajs/vue3": "^1.0.0",
+        "@inertiajs/vue3": "^3.0.3",
         "@tailwindcss/forms": "^0.5.3",
         "@types/dompurify": "^3.0.5",
         "@types/micromodal": "^0.3.5",

--- a/resources/js/app.ts
+++ b/resources/js/app.ts
@@ -3,7 +3,7 @@ import './micromodal';
 import '../css/app.css';
 import '../css/micromodal.css';
 
-import type { App, DefineComponent } from "vue";
+import type { DefineComponent } from "vue";
 import { createApp, h } from 'vue';
 import { createInertiaApp } from '@inertiajs/vue3';
 import { resolvePageComponent } from 'laravel-vite-plugin/inertia-helpers';
@@ -18,14 +18,11 @@ createInertiaApp({
             `./Pages/${name}.vue`,
             import.meta.glob<DefineComponent>('./Pages/**/*.vue')
         ),
-    setup({ el, App, props, plugin }): App {
+    setup({ el, App, props, plugin }): void {
         const app = createApp({ render: () => h(App, props) })
             .use(plugin)
             .use(ZiggyVue);
-
         app.mount(el);
-
-        return app;
     },
     progress: {
         color: '#4B5563',

--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
 
-        <title inertia>{{ config('app.name', 'Laravel') }}</title>
+        <title data-inertia>{{ config('app.name', 'Laravel') }}</title>
 
         <!-- Fonts -->
         <link rel="preconnect" href="https://fonts.bunny.net">


### PR DESCRIPTION
## 目的

Inertia.js を v1 から v3 へアップグレードすることにより以下の問題の解消をする
- lodash・lodash-es（コードインジェクション・Prototype Pollution）の脆弱性を解消
- qs（DoS）の脆弱性を解消
- Inertia v1 のメンテナンス終了に備えた対応

## 関連Issue

- 関連Issue: #584

## パッケージの変更

| パッケージ | 言語 | 変更前 | 変更後 |
|---|---|---|---|
| @inertiajs/vue3 | JavaScript（フロント） | v1 | v3 |
| inertia-laravel | PHP（バックエンド） | v1 | v2 |

## コードの変更点

### resources/js/app.ts
- `setup` コールバックの戻り値を `App` → `void` に変更
- `App` の import を削除

### resources/views/app.blade.php
- `<title inertia>` → `<title data-inertia>` に変更