### PR TITLE
fix: add legacy.inconsistentCjsInterop to vite.config.ts to resolve V…

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -23,4 +23,7 @@ export default defineConfig({
             '@': path.resolve(__dirname, './resources/js'),
         },
     },
+    legacy: {
+        inconsistentCjsInterop: true,
+    },
 });


### PR DESCRIPTION
## 目的

Vite 8 へのアップグレードにより本番環境で発生した
"F is not a function" エラーの修正

## 変更点

- 変更ファイル
- `vite.config.ts`

## 変更内容
Vite 8 は内部バンドラーが Rollup から Rolldown に変わり
CJS モジュールのインポート処理が変更された。
`legacy.inconsistentCjsInterop: true` を追加することで
以前の挙動に戻し、CJS パッケージ（micromodal・ziggy）が
正常に動作するようにした。