### PR TITLE
fix: switch ziggy import from vendor path to npm package for Vite 8 E…

### DIFF
--- a/resources/js/app.ts
+++ b/resources/js/app.ts
@@ -7,7 +7,7 @@ import type { DefineComponent } from "vue";
 import { createApp, h } from 'vue';
 import { createInertiaApp } from '@inertiajs/vue3';
 import { resolvePageComponent } from 'laravel-vite-plugin/inertia-helpers';
-import { ZiggyVue } from '../../vendor/tightenco/ziggy';
+import { ZiggyVue } from 'ziggy-js';
 
 const appName = import.meta.env.VITE_APP_NAME || 'Laravel';
 


### PR DESCRIPTION
## 目的

Vite 8 へのアップグレードにより本番環境で発生していた
"F is not a function" エラーの修正

## 背景
Vite 8 は内部バンドラーが Rollup から Rolldown に変わり
CJS モジュールの処理方法が変更された。

これまで `app.ts` では ziggy を vendor フォルダから直接参照していたが
vendor フォルダは node_modules 経由ではないため
Rolldown の依存関係の最適化対象外となり
CJS/ESM の判定が正しく行われず本番ビルドでエラーが発生していたと思われる。

## 変更ファイル
- `resources/js/app.ts`

## 変更内容

### ziggy のインポート元を変更

```typescript
// 変更前（vendor フォルダから直接参照）
import { ZiggyVue } from '../../vendor/tightenco/ziggy';

// 変更後（npm パッケージから参照）
import { ZiggyVue } from 'ziggy-js';
```