### PR TITLE
fix: add resolve alias to use micromodal ESM build for Vite 8 compati…

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -21,6 +21,7 @@ export default defineConfig({
     resolve: {
         alias: {
             '@': path.resolve(__dirname, './resources/js'),
+            'micromodal': path.resolve(__dirname, 'node_modules/micromodal/dist/micromodal.es.js'),
         },
     },
     legacy: {


### PR DESCRIPTION
## 目的

Vite 8 へのアップグレードにより本番環境で発生していた
"F is not a function" エラーの修正（micromodal の ESM 対応）

## 背景
Vite 8 は内部バンドラーが Rollup から Rolldown に変わり
CJS モジュールの処理方法が変更された。

micromodal は `package.json` の `main` フィールドに CJS 版（`dist/micromodal.js`）が
設定されているため、Rolldown がデフォルトで CJS 版を読み込み
本番ビルドで "F is not a function" エラーが発生していた。

## 変更ファイル
- `vite.config.ts`

## 変更内容

### resolve.alias で micromodal の ESM 版を明示

```typescript
// 変更前
resolve: {
    alias: {
        '@': path.resolve(__dirname, './resources/js'),
    },
},

// 変更後
resolve: {
    alias: {
        '@': path.resolve(__dirname, './resources/js'),
        'micromodal': path.resolve(__dirname, 'node_modules/micromodal/dist/micromodal.es.js'),
    },
},
```

これにより `import MicroModal from 'micromodal'` が
自動的に ESM 版（`dist/micromodal.es.js`）を参照するようになる。