### PR TITLE
fix: move micromodal to vendor chunk to resolve Vite 8 Rolldown CJS e…

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -18,6 +18,17 @@ export default defineConfig({
             },
         }),
     ],
+    build: {
+        rolldownOptions: {
+            output: {
+                manualChunks: (id: string) => {
+                    if (id.includes('micromodal')) {
+                        return 'vendor'
+                    }
+                }
+            }
+        }
+    },
     resolve: {
         alias: {
             '@': path.resolve(__dirname, './resources/js'),


### PR DESCRIPTION
## 目的

Vite 8 へのアップグレードにより本番環境で発生していた
"F is not a function" エラーの修正（micromodal のチャンク分割問題）

## 背景
Vite 8 は内部バンドラーが Rollup から Rolldown に変わった。
Rolldown はチャンク間で CJS モジュールを受け渡す際に
デフォルトインポートをオブジェクトとして解釈するため
関数として呼び出すと "F is not a function" エラーが発生する。

micromodal が自動的に別チャンクに分割されることで
チャンク間の受け渡し時にこの問題が発生していた。

## 変更ファイル
- `vite.config.ts`

## 変更内容

### micromodal を vendor チャンクに手動で割り当て

```typescript
build: {
    rolldownOptions: {
        output: {
            manualChunks: (id: string) => {
                if (id.includes('micromodal')) {
                    return 'vendor'
                }
            }
        }
    }
},
```

micromodal を `vendor` チャンクに固定することで
チャンク間の CJS モジュールの受け渡しが発生しなくなり
エラーが解消されると思われる。