### PR TITLE
fix: docker-compose.ymlファイルを整理

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,8 +67,6 @@ services:
             MYSQL_DATABASE: ems_testing
             MYSQL_USER: ems_testing
             MYSQL_PASSWORD: password123
-        volumes:
-            - './vendor/laravel/sail/database/mysql/create-testing-database.sh:/docker-entrypoint-initdb.d/10-create-testing-database.sh'
         networks:
             - sail
         healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,5 @@
 services:
     my-laravel-app:
-        container_name: EMS
         build:
             context: .
             dockerfile: Dockerfile
@@ -34,9 +33,8 @@ services:
         depends_on:
             - mysql
             - mysql-test
-        
+
     mysql:
-        container_name: mysql
         image: 'mysql:8.0'
         ports:
             - '${FORWARD_DB_PORT:-3306}:3306'
@@ -48,7 +46,6 @@ services:
             MYSQL_PASSWORD: '${DB_PASSWORD}'
             MYSQL_ALLOW_EMPTY_PASSWORD: 1
         volumes:
-            - 'sail-mysql-test:/var/lib/mysql'
             - 'sail-mysql:/var/lib/mysql'
         networks:
             - sail
@@ -61,7 +58,6 @@ services:
             retries: 3
             timeout: 5s
     mysql-test:
-        container_name: mysql-test
         image: 'mysql:8.0'
         ports:
             - '3307:3306'
@@ -84,10 +80,7 @@ services:
             retries: 3
             timeout: 5s
     phpMyAdmin:
-        container_name: phpMyAdmin
         image: phpmyadmin/phpmyadmin
-        links:
-            - 'mysql:mysql'
         ports:
             - '8080:80'
         environment:
@@ -104,5 +97,3 @@ networks:
 volumes:
     sail-mysql:
         driver: local
-    sail-mysql-test:
-    driver: 


### PR DESCRIPTION
## 目的

ローカル環境にcloneして正常にDockerコンテナが起動するよう、docker-compose.ymlを修正しました。

## 変更点

1. container_name 4箇所を削除
2. mysql の volume 二重マウントを解消
3. トップレベル volumes: を sail-mysql のみに修正
4. mysql-test から volume セクションを削除
5. phpMyAdmin の links を削除