### PR TITLE
refactor: 正常系の Log::info を削除

### DIFF
--- a/app/Http/Controllers/Api/EdithistoryController.php
+++ b/app/Http/Controllers/Api/EdithistoryController.php
@@ -5,14 +5,11 @@ namespace App\Http\Controllers\Api;
 use App\Http\Controllers\Controller;
 use App\Models\Edithistory;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Log;
 
 class EdithistoryController extends Controller
 {
     public function index(Request $request)
     {
-        Log::info('EdithistoryController index method called');
-
         // 編集履歴で表示するために、更新種類と更新フィールドを日本語に変換する必要がある
         $edithistories = Edithistory::where('item_id', $request->item_id)
             ->with('editReason')
@@ -22,42 +19,40 @@ class EdithistoryController extends Controller
             ->map(function ($edithistory) {
                 // operation_typeの編集履歴に表示用の値を設定
                 $edithistory->operation_type_for_display = match ($edithistory->operation_type) {
-                    'store'                     => '新規登録',
-                    'update'                    => '編集更新',
-                    'soft_delete'               => '廃棄',
-                    'restore'                   => '復元',
-                    'inspection'                => '点検',
-                    default                     => '不明',
+                    'store' => '新規登録',
+                    'update' => '編集更新',
+                    'soft_delete' => '廃棄',
+                    'restore' => '復元',
+                    'inspection' => '点検',
+                    default => '不明',
                 };
                 // edited_fieldの編集履歴に表示用の値を設定
                 $edithistory->edited_field_for_display = match ($edithistory->edited_field) {
-                    'name'                      => '備品名',
-                    'category_id'               => 'カテゴリ',
-                    'image1'                    => '画像',
-                    'stock'                     => '在庫数',
-                    'unit_id'                   => '単位',
-                    'minimum_stock'             => '通知在庫数',
-                    'notification'              => '通知オンオフ',
-                    'usage_status_id'           => '利用状況',
-                    'end_user'                  => '利用者',
-                    'location_of_use_id'        => '利用場所',
-                    'storage_location_id'       => '保管場所',
-                    'acquisition_method_id'     => '取得区分',
-                    'acquisition_source'        => '取得先',
-                    'price'                     => '取得価額',
-                    'date_of_acquisition'       => '取得年月日',
-                    'manufacturer'              => 'メーカー',
-                    'product_number'            => '製品番号',
-                    'remarks'                   => '備考',
+                    'name' => '備品名',
+                    'category_id' => 'カテゴリ',
+                    'image1' => '画像',
+                    'stock' => '在庫数',
+                    'unit_id' => '単位',
+                    'minimum_stock' => '通知在庫数',
+                    'notification' => '通知オンオフ',
+                    'usage_status_id' => '利用状況',
+                    'end_user' => '利用者',
+                    'location_of_use_id' => '利用場所',
+                    'storage_location_id' => '保管場所',
+                    'acquisition_method_id' => '取得区分',
+                    'acquisition_source' => '取得先',
+                    'price' => '取得価額',
+                    'date_of_acquisition' => '取得年月日',
+                    'manufacturer' => 'メーカー',
+                    'product_number' => '製品番号',
+                    'remarks' => '備考',
                     'inspection_scheduled_date' => '点検予定日',
-                    'disposal_scheduled_date'   => '廃棄予定日',
-                    default                     => null,
+                    'disposal_scheduled_date' => '廃棄予定日',
+                    default => null,
                 };
 
                 return $edithistory;
             });
-
-        Log::info('EdithistoryController index method succeeded');
 
         return [
             'edithistories' => $edithistories,

--- a/app/Http/Controllers/Api/ItemController.php
+++ b/app/Http/Controllers/Api/ItemController.php
@@ -4,25 +4,20 @@ namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
 use App\Models\Item;
-use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Log;
 
 class ItemController extends Controller
 {
     public function restore($id)
     {
-        Log::info('Api/ItemController restore method called');
-
         $item = Item::withTrashed()->find($id);
         if ($item) {
             $item->restore();
 
-            Log::info('Api/ItemController restore method succeeded');
-
             return response()->json([
                 'message' => '備品を復元しました',
-                'status'  => 'success',
-                'item'    => $item, // 復元したアイテムの情報を返す
+                'status' => 'success',
+                'item' => $item, // 復元したアイテムの情報を返す
             ]);
         }
 
@@ -30,7 +25,7 @@ class ItemController extends Controller
 
         return response()->json([
             'message' => '該当の備品が存在しませんでした',
-            'status'  => 'danger',
+            'status' => 'danger',
         ], 404);
     }
 }

--- a/app/Http/Controllers/Api/ItemRequestController.php
+++ b/app/Http/Controllers/Api/ItemRequestController.php
@@ -6,7 +6,6 @@ use App\Http\Controllers\Controller;
 use App\Models\ItemRequest;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Gate;
-use Illuminate\Support\Facades\Log;
 
 class ItemRequestController extends Controller
 {
@@ -14,14 +13,10 @@ class ItemRequestController extends Controller
     {
         Gate::authorize('staff-higher');
 
-        Log::info('ItemRequestController updateStatus api method called');
-
         // $idはURLパラメータから取得される
-        $itemRequest                    = ItemRequest::findOrFail($id);
+        $itemRequest = ItemRequest::findOrFail($id);
         $itemRequest->request_status_id = $request->requestStatusId;
         $itemRequest->save();
-
-        Log::info('ItemRequestController updateStatus api method succeeded');
 
         return response()->json(['message' => 'Status updated successfully'], 200);
     }

--- a/app/Http/Controllers/Api/NotificationController.php
+++ b/app/Http/Controllers/Api/NotificationController.php
@@ -5,7 +5,6 @@ namespace App\Http\Controllers\Api;
 use App\Http\Controllers\Controller;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Gate;
-use Illuminate\Support\Facades\Log;
 
 class NotificationController extends Controller
 {
@@ -14,11 +13,10 @@ class NotificationController extends Controller
     {
         Gate::authorize('staff-higher');
 
-        Log::info('NotificationController API markAsRead method called');
-
         $notification = Auth::user()->notifications()->find($id);
         if ($notification) {
             $notification->markAsRead();
+
             return response()->noContent(); // No Content=204レスポンス、レスポンスにコンテンツが含まれない
         }
 

--- a/app/Http/Controllers/Api/StockTransactionController.php
+++ b/app/Http/Controllers/Api/StockTransactionController.php
@@ -7,14 +7,11 @@ use App\Models\Item;
 use App\Models\StockTransaction;
 use Carbon\Carbon;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Log;
 
 class StockTransactionController extends Controller
 {
     public function index(Request $request)
     {
-        Log::info('StockTransactionController API stockTransaction method called');
-
         $item = Item::find($request->item_id);
 
         // stock_transactionsを取得 withを使うとitemの情報すべてが取れてくる
@@ -33,28 +30,26 @@ class StockTransactionController extends Controller
             $transaction->current_stock = $current_stock;
 
             // 次のレコードの在庫数を計算、次に持ち越し
-            $current_stock -= $transaction->quantity; //過去に遡るからマイナス
+            $current_stock -= $transaction->quantity; // 過去に遡るからマイナス
 
             // 曜日は日本語で表示する
-            $daysOfWeek                        = ['日', '月', '火', '水', '木', '金', '土'];
-            $created_at                        = Carbon::parse($transaction->created_at);
-            $japaneseDayOfWeek                 = $daysOfWeek[$created_at->dayOfWeek];
-            $transaction->formatted_created_at = $created_at->format('Y-m-d') . " ({$japaneseDayOfWeek}) " . $created_at->format('H:i');
+            $daysOfWeek = ['日', '月', '火', '水', '木', '金', '土'];
+            $created_at = Carbon::parse($transaction->created_at);
+            $japaneseDayOfWeek = $daysOfWeek[$created_at->dayOfWeek];
+            $transaction->formatted_created_at = $created_at->format('Y-m-d')." ({$japaneseDayOfWeek}) ".$created_at->format('H:i');
         });
 
         // グラフ用のデータを準備、時系列を左から右にするため配列を逆順にする
-        $labels            = array_reverse($stock_transactions->pluck('formatted_created_at')->toArray());
-        $stocks            = array_reverse($stock_transactions->pluck('current_stock')->toArray());
+        $labels = array_reverse($stock_transactions->pluck('formatted_created_at')->toArray());
+        $stocks = array_reverse($stock_transactions->pluck('current_stock')->toArray());
         $transaction_types = array_reverse($stock_transactions->pluck('transaction_type')->toArray());
-
-        Log::info('StockTransactionController API stockTransaction method succeeded');
 
         return [
             'stockTransactions' => $stock_transactions,
-            'labels'            => $labels,
-            'stocks'            => $stocks,
+            'labels' => $labels,
+            'stocks' => $stocks,
             'transaction_types' => $transaction_types,
-            'minimum_stock'     => $item->minimum_stock,
+            'minimum_stock' => $item->minimum_stock,
         ];
     }
 }

--- a/app/Http/Controllers/ConsumableItemController.php
+++ b/app/Http/Controllers/ConsumableItemController.php
@@ -2,7 +2,6 @@
 
 namespace App\Http\Controllers;
 
-use App\Http\Controllers\Controller;
 use App\Models\Item;
 use App\Models\Location;
 use App\Services\ImageService;
@@ -13,6 +12,7 @@ use Inertia\Inertia;
 class ConsumableItemController extends Controller
 {
     const CONSUMABLE_ITEM_CATEGORY_ID = 1;
+
     protected $imageService;
 
     public function __construct(ImageService $imageService)
@@ -22,13 +22,12 @@ class ConsumableItemController extends Controller
 
     public function index(Request $request, $item_id = null)
     {
-        Log::info('ConsumableItemController index method called');
 
         try {
-            $search    = $request->query('search', '');
+            $search = $request->query('search', '');
             $sortOrder = $request->query('sortOrder', 'desc');
             // プルダウンの数値、第2引数は初期値で0
-            $location_of_use_id  = $request->query('locationOfUseId', 0);
+            $location_of_use_id = $request->query('locationOfUseId', 0);
             $storage_location_id = $request->query('storageLocationId', 0);
 
             $withRelations = [
@@ -83,48 +82,47 @@ class ConsumableItemController extends Controller
             }
 
             // 消耗品の合計件数
-            $total_count     = $query->count();
+            $total_count = $query->count();
             $consumableItems = $query->paginate(20);
 
             $current_page = $consumableItems->currentPage();                                  // 現在のページ番号
-            $per_page     = $consumableItems->perPage();                                      // 1ページあたりの項目数
+            $per_page = $consumableItems->perPage();                                      // 1ページあたりの項目数
             $start_number = ($current_page - 1) * $per_page + 1;                              // 現在のページの最初の項目番号
-            $end_number   = min($start_number + $consumableItems->count() - 1, $total_count); // 現在のページの最後の項目番号
+            $end_number = min($start_number + $consumableItems->count() - 1, $total_count); // 現在のページの最後の項目番号
 
             // map関数を使用するとpaginateオブジェクトの構造が変わり、ペジネーションが使えなくなるのでtransformを使う
             $consumableItems->getCollection()->transform(function ($consumableItem) {
                 $this->imageService->setImagePathToObject($consumableItem);
+
                 return $consumableItem;
             });
 
             // プルダウン用データ
             $locations = Location::all();
-            $user      = auth()->user();
+            $user = auth()->user();
 
             // Notification.vueのリンククリックで送られてきたItemのid
             $linkedItem = Item::with($withRelations)
                 ->select($selectFields)
                 ->find($item_id);
 
-            Log::info('ConsumableItemController index method succeeded');
-
             return Inertia::render('ConsumableItems/Index', [
-                'consumableItems'   => $consumableItems,
-                'locations'         => $locations,
-                'search'            => $search,
-                'sortOrder'         => $sortOrder,
-                'locationOfUseId'   => $location_of_use_id,
+                'consumableItems' => $consumableItems,
+                'locations' => $locations,
+                'search' => $search,
+                'sortOrder' => $sortOrder,
+                'locationOfUseId' => $location_of_use_id,
                 'storageLocationId' => $storage_location_id,
-                'totalCount'        => $total_count,
-                'userName'          => $user->name,
-                'linkedItem'        => $linkedItem,
-                'startNumber'       => $start_number,
-                'endNumber'         => $end_number,
+                'totalCount' => $total_count,
+                'userName' => $user->name,
+                'linkedItem' => $linkedItem,
+                'startNumber' => $start_number,
+                'endNumber' => $end_number,
             ]);
         } catch (\Exception $e) {
             Log::error('ConsumableItemController index method failed', [
-                'error'   => $e->getMessage(),
-                'stack'   => $e->getTraceAsString(),
+                'error' => $e->getMessage(),
+                'stack' => $e->getTraceAsString(),
                 'request' => $request->all(),
             ]);
         }

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -2,49 +2,45 @@
 
 namespace App\Http\Controllers;
 
-use App\Http\Controllers\Controller;
 use App\UseCases\Dashboard\GroupedEditHistoriesUseCase;
 use App\UseCases\Dashboard\ItemsByTypeUseCase;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Log;
 use Inertia\Inertia;
 
 class DashboardController extends Controller
 {
     private $itemsByTypeUseCase;
+
     private $groupedEditHistories;
 
     public function __construct(
         ItemsByTypeUseCase $itemsByTypeUseCase,
         GroupedEditHistoriesUseCase $groupedEditHistories
     ) {
-        $this->itemsByTypeUseCase   = $itemsByTypeUseCase;
+        $this->itemsByTypeUseCase = $itemsByTypeUseCase;
         $this->groupedEditHistories = $groupedEditHistories;
     }
 
     public function index(Request $request)
     {
-        Log::info('DashboardController index method called');
 
         try {
-            $type                                                        = $request->input('type', 'category');
-            list('allItems' => $allItems, 'itemsByType' => $itemsByType) = $this->itemsByTypeUseCase->handle($type);
+            $type = $request->input('type', 'category');
+            ['allItems' => $allItems, 'itemsByType' => $itemsByType] = $this->itemsByTypeUseCase->handle($type);
 
             $groupedEditHistories = $this->groupedEditHistories->handle();
 
-            Log::info('DashboardController index method succeeded');
-
             return Inertia::render('Dashboard', [
-                'allItems'             => $allItems,
-                'itemsByType'          => $itemsByType,
+                'allItems' => $allItems,
+                'itemsByType' => $itemsByType,
                 'groupedEdithistories' => $groupedEditHistories,
-                'type'                 => $type,
+                'type' => $type,
             ]);
         } catch (\Exception $e) {
             Log::error('DashboardController index method failed', [
-                'error'   => $e->getMessage(),
-                'stack'   => $e->getTraceAsString(),
+                'error' => $e->getMessage(),
+                'stack' => $e->getTraceAsString(),
                 'request' => $request->all(),
             ]);
         }

--- a/app/Http/Controllers/DisposalController.php
+++ b/app/Http/Controllers/DisposalController.php
@@ -2,7 +2,6 @@
 
 namespace App\Http\Controllers;
 
-use App\Http\Controllers\Controller;
 use App\Http\Requests\StoreDisposalRequest;
 use App\Models\Disposal;
 use App\Models\Edithistory;
@@ -17,22 +16,20 @@ class DisposalController extends Controller
     {
         DB::beginTransaction();
 
-        Log::info('DisposalController disposeItem method called');
-
         try {
             $disposal = Disposal::where('item_id', $item->id)->first();
 
             if (is_null($disposal)) {
                 // 新しいレコードを作成
-                $disposal          = new Disposal();
+                $disposal = new Disposal;
                 $disposal->item_id = $item->id;
             }
 
             // 廃棄が実施されたので、予定日は初期化にする
             $disposal->disposal_scheduled_date = null;
-            $disposal->disposal_date           = $request->disposal_date;
-            $disposal->disposal_person         = $request->disposal_person;
-            $disposal->details                 = $request->details;
+            $disposal->disposal_date = $request->disposal_date;
+            $disposal->disposal_person = $request->disposal_person;
+            $disposal->details = $request->details;
 
             // DisposalObserverを一時的に無効にして保存
             Disposal::withoutEvents(function () use ($disposal) {
@@ -44,37 +41,35 @@ class DisposalController extends Controller
 
             // 廃棄したというoperation_typeのみをDBに保存する
             Edithistory::create([
-                'edit_mode'      => 'normal',
+                'edit_mode' => 'normal',
                 'operation_type' => 'soft_delete',
-                'item_id'        => $item->id,
-                'edited_field'   => null,
-                'old_value'      => null,
-                'new_value'      => null,
-                'edit_user'      => Auth::user()->name ?? '',
+                'item_id' => $item->id,
+                'edited_field' => null,
+                'old_value' => null,
+                'new_value' => null,
+                'edit_user' => Auth::user()->name ?? '',
             ]);
 
             DB::commit();
 
-            Log::info('DisposalController disposeItem method succeeded');
-
             return to_route('items.index')
                 ->with([
                     'message' => '廃棄しました。',
-                    'status'  => 'danger',
+                    'status' => 'danger',
                 ]);
         } catch (\Exception $e) {
             DB::rollBack();
 
             Log::error('DisposalController disposeItem method Transaction failed', [
-                'error'   => $e->getMessage(),
-                'stack'   => $e->getTraceAsString(),
+                'error' => $e->getMessage(),
+                'stack' => $e->getTraceAsString(),
                 'request' => $request->all(),
             ]);
 
             return redirect()->back()
                 ->with([
                     'message' => '登録中にエラーが発生しました',
-                    'status'  => 'danger',
+                    'status' => 'danger',
                 ]);
         }
     }

--- a/app/Http/Controllers/InspectionAndDisposalItemController.php
+++ b/app/Http/Controllers/InspectionAndDisposalItemController.php
@@ -2,21 +2,23 @@
 
 namespace App\Http\Controllers;
 
-use App\Http\Controllers\Controller;
 use App\Services\ImageService;
 use App\UseCases\InspectionAndDisposalItem\HistoryDisposalUseCase;
 use App\UseCases\InspectionAndDisposalItem\HistoryInspectionsUseCase;
 use App\UseCases\InspectionAndDisposalItem\ScheduledDisposalUseCase;
 use App\UseCases\InspectionAndDisposalItem\ScheduledInspectionsUseCase;
-use Illuminate\Support\Facades\Log;
 use Inertia\Inertia;
 
 class InspectionAndDisposalItemController extends Controller
 {
     protected $imageService;
+
     protected $scheduledInspectionsUseCase;
+
     protected $historyInspectionsUseCase;
+
     protected $scheduledDisposalUseCase;
+
     protected $historyDisposalUseCase;
 
     public function __construct(
@@ -26,29 +28,25 @@ class InspectionAndDisposalItemController extends Controller
         ScheduledDisposalUseCase $scheduledDisposalUseCase,
         HistoryDisposalUseCase $historyDisposalUseCase
     ) {
-        $this->imageService                = $imageService;
+        $this->imageService = $imageService;
         $this->scheduledInspectionsUseCase = $scheduledInspectionsUseCase;
-        $this->historyInspectionsUseCase   = $historyInspectionsUseCase;
-        $this->scheduledDisposalUseCase    = $scheduledDisposalUseCase;
-        $this->historyDisposalUseCase      = $historyDisposalUseCase;
+        $this->historyInspectionsUseCase = $historyInspectionsUseCase;
+        $this->scheduledDisposalUseCase = $scheduledDisposalUseCase;
+        $this->historyDisposalUseCase = $historyDisposalUseCase;
     }
 
     public function index()
     {
-        Log::info('InspectionAndDisposalItemController index method called');
-
         $scheduledInspections = $this->scheduledInspectionsUseCase->handle();
-        $historyInspections   = $this->historyInspectionsUseCase->handle();
-        $scheduledDisposals   = $this->scheduledDisposalUseCase->handle();
-        $historyDisposals     = $this->historyDisposalUseCase->handle();
-
-        Log::info('InspectionAndDisposalItemController index method succeeded');
+        $historyInspections = $this->historyInspectionsUseCase->handle();
+        $scheduledDisposals = $this->scheduledDisposalUseCase->handle();
+        $historyDisposals = $this->historyDisposalUseCase->handle();
 
         return Inertia::render('InspectionAndDisposalItems/Index', [
             'scheduledInspections' => $scheduledInspections,
-            'scheduledDisposals'   => $scheduledDisposals,
-            'historyInspections'   => $historyInspections,
-            'historyDisposals'     => $historyDisposals,
+            'scheduledDisposals' => $scheduledDisposals,
+            'historyInspections' => $historyInspections,
+            'historyDisposals' => $historyDisposals,
         ]);
     }
 }

--- a/app/Http/Controllers/InspectionController.php
+++ b/app/Http/Controllers/InspectionController.php
@@ -2,7 +2,6 @@
 
 namespace App\Http\Controllers;
 
-use App\Http\Controllers\Controller;
 use App\Http\Requests\StoreInspectionRequest;
 use App\Models\Edithistory;
 use App\Models\Inspection;
@@ -17,8 +16,6 @@ class InspectionController extends Controller
     {
         DB::beginTransaction();
 
-        Log::info('InspectionController inspectItem method called');
-
         try {
             // 処理１、Inspectionテーブルのstatusがfalseの登録日が一番古い日付のレコードを取得
             $inspection = Inspection::where('item_id', $item->id)
@@ -30,17 +27,17 @@ class InspectionController extends Controller
             // 処理２，予定日を保存していない場合はレコードが返らずnullとなるので新規作成
             if (is_null($inspection)) {
                 // 新しいレコードを作成
-                $inspection          = new Inspection();
+                $inspection = new Inspection;
                 $inspection->item_id = $item->id;
-                $inspection->status  = false;
+                $inspection->status = false;
             }
 
             // 処理３，Inspectionテーブルのレコードに値を保存
             // $inspection->scheduled_date = null; // 廃棄の時のようにレコードを使いまわさず、記録として残す
-            $inspection->inspection_date   = $request->inspection_date;
+            $inspection->inspection_date = $request->inspection_date;
             $inspection->inspection_person = $request->inspection_person;
-            $inspection->details           = $request->details;
-            $inspection->status            = true; // 点検実行済みとしてstatusを変更
+            $inspection->details = $request->details;
+            $inspection->status = true; // 点検実行済みとしてstatusを変更
 
             // InspectionObserverを一時的に無効にして保存
             Inspection::withoutEvents(function () use ($inspection) {
@@ -49,39 +46,37 @@ class InspectionController extends Controller
 
             // 点検をしたというoperation_typeのみをDBに保存する
             Edithistory::create([
-                'edit_mode'        => 'normal',
-                'operation_type'   => 'inspection',
-                'item_id'          => $inspection->item_id,
-                'edited_field'     => null,
-                'old_value'        => null,
-                'new_value'        => null,
-                'edit_user'        => Auth::user()->name ?? '',
-                'edit_reason_id'   => null, //プルダウン
-                'edit_reason_text' => null, //その他テキストエリア
+                'edit_mode' => 'normal',
+                'operation_type' => 'inspection',
+                'item_id' => $inspection->item_id,
+                'edited_field' => null,
+                'old_value' => null,
+                'new_value' => null,
+                'edit_user' => Auth::user()->name ?? '',
+                'edit_reason_id' => null, // プルダウン
+                'edit_reason_text' => null, // その他テキストエリア
             ]);
 
             DB::commit();
 
-            Log::info('InspectionController inspectItem method succeeded');
-
             return to_route('items.show', ['item' => $item->id])
                 ->with([
                     'message' => '点検を実施しました。',
-                    'status'  => 'success',
+                    'status' => 'success',
                 ]);
         } catch (\Exception $e) {
             DB::rollBack();
 
             Log::error('InspectionController inspectItem method Transaction failed', [
-                'error'   => $e->getMessage(),
-                'stack'   => $e->getTraceAsString(),
+                'error' => $e->getMessage(),
+                'stack' => $e->getTraceAsString(),
                 'request' => $request->all(),
             ]);
 
             return redirect()->back()
                 ->with([
                     'message' => '登録中にエラーが発生しました',
-                    'status'  => 'danger',
+                    'status' => 'danger',
                 ]);
         }
     }

--- a/app/Http/Controllers/ItemController.php
+++ b/app/Http/Controllers/ItemController.php
@@ -2,7 +2,6 @@
 
 namespace App\Http\Controllers;
 
-use App\Http\Controllers\Controller;
 use App\Http\Requests\StoreItemRequest;
 use App\Http\Requests\UpdateItemRequest;
 use App\Models\AcquisitionMethod;
@@ -29,8 +28,11 @@ use Inertia\Inertia;
 class ItemController extends Controller
 {
     const CATEGORY_ID_FOR_CONSUMABLE_ITME = 1;
+
     protected $managementIdService;
+
     protected $imageService;
+
     protected $qrCodeService;
 
     public function __construct(
@@ -39,8 +41,8 @@ class ItemController extends Controller
         QrCodeService $qrCodeService
     ) {
         $this->managementIdService = $managementIdService;
-        $this->imageService        = $imageService;
-        $this->qrCodeService       = $qrCodeService;
+        $this->imageService = $imageService;
+        $this->qrCodeService = $qrCodeService;
 
         // ミドルウェアの設定
         $this->middleware('RestrictGuestAccess', ['only' => ['store', 'update', 'destroy', 'restore']]);
@@ -48,7 +50,6 @@ class ItemController extends Controller
 
     public function index(Request $request)
     {
-        Log::info('ItemController index method called');
 
         try {
             $search = $request->query('search', '');
@@ -57,13 +58,13 @@ class ItemController extends Controller
             $sortOrder = $request->query('sortOrder', 'desc');
 
             // プルダウンの数値、第2引数は初期値で0
-            $category_id         = $request->query('categoryId', 0);
-            $location_of_use_id  = $request->query('locationOfUseId', 0);
+            $category_id = $request->query('categoryId', 0);
+            $location_of_use_id = $request->query('locationOfUseId', 0);
             $storage_location_id = $request->query('storageLocationId', 0);
-            $disposal            = $request->query('disposal', 'false');
+            $disposal = $request->query('disposal', 'false');
 
             $withRelations = ['category', 'unit', 'usageStatus', 'locationOfUse', 'storageLocation', 'acquisitionMethod', 'inspections', 'disposal'];
-            $selectFields  = [
+            $selectFields = [
                 'id',
                 'management_id',
                 'name',
@@ -117,16 +118,16 @@ class ItemController extends Controller
             }
 
             $total_count = $query->count();
-            $items       = $query->paginate(20);
+            $items = $query->paginate(20);
 
             $current_page = $items->currentPage(); // 現在のページ番号
-            $per_page     = $items->perPage();     // 1ページあたりの項目数
+            $per_page = $items->perPage();     // 1ページあたりの項目数
             if ($total_count !== 0) {
                 $start_number = ($current_page - 1) * $per_page + 1;                    // 現在のページの最初の項目番号
-                $end_number   = min($start_number + $items->count() - 1, $total_count); // 現在のページの最後の項目番号
+                $end_number = min($start_number + $items->count() - 1, $total_count); // 現在のページの最後の項目番号
             } else {
                 $start_number = 0;
-                $end_number   = 0;
+                $end_number = 0;
             }
 
             // map関数を使用するとpaginateオブジェクトの構造が変わり、ペジネーションが使えなくなる
@@ -136,8 +137,9 @@ class ItemController extends Controller
 
             $items->getCollection()->transform(function ($item) {
                 // inspection_scheduled_dateを追加
-                $inspection                      = $item->inspections->where('status', false)->sortBy('inspection_scheduled_date')->first();
+                $inspection = $item->inspections->where('status', false)->sortBy('inspection_scheduled_date')->first();
                 $item->inspection_scheduled_date = $inspection ? $inspection->inspection_scheduled_date : null;
+
                 return $item;
             });
 
@@ -146,76 +148,70 @@ class ItemController extends Controller
 
             // プルダウン用データ
             $categories = Category::all();
-            $locations  = Location::all();
-
-            Log::info('ItemController index method succeeded');
+            $locations = Location::all();
 
             return Inertia::render('Items/Index', [
-                'items'             => $items,
-                'categories'        => $categories,
-                'locations'         => $locations,
-                'search'            => $search,
-                'sortOrder'         => $sortOrder,
-                'categoryId'        => $category_id,
-                'locationOfUseId'   => $location_of_use_id,
+                'items' => $items,
+                'categories' => $categories,
+                'locations' => $locations,
+                'search' => $search,
+                'sortOrder' => $sortOrder,
+                'categoryId' => $category_id,
+                'locationOfUseId' => $location_of_use_id,
                 'storageLocationId' => $storage_location_id,
-                'totalCount'        => $total_count,
-                'startNumber'       => $start_number,
-                'endNumber'         => $end_number,
-                'disposal'          => $disposal,
+                'totalCount' => $total_count,
+                'startNumber' => $start_number,
+                'endNumber' => $end_number,
+                'disposal' => $disposal,
             ]);
         } catch (\Exception $e) {
             Log::error('ItemController index method failed', [
-                'error'   => $e->getMessage(),
-                'stack'   => $e->getTraceAsString(),
+                'error' => $e->getMessage(),
+                'stack' => $e->getTraceAsString(),
                 'request' => $request->all(),
             ]);
 
             return redirect()->back()
                 ->with([
                     'message' => '予期しないエラーが発生しました',
-                    'status'  => 'danger',
+                    'status' => 'danger',
                 ]);
         }
     }
 
     public function create(Request $request)
     {
-        Log::info('ItemController create method called');
 
-        $categories          = Category::all();
-        $locations           = Location::all();
-        $units               = Unit::all();
-        $usage_statuses      = UsageStatus::all();
+        $categories = Category::all();
+        $locations = Location::all();
+        $units = Unit::all();
+        $usage_statuses = UsageStatus::all();
         $acquisition_methods = AcquisitionMethod::all();
-
-        Log::info('ItemController create method succeeded');
 
         // $request->queryはリクエスト一覧から「新規作成」でCreate.vueを開いたときに自動入力する値
         return Inertia::render('Items/Create', [
-            'categories'         => $categories,
-            'locations'          => $locations,
-            'units'              => $units,
-            'usageStatuses'      => $usage_statuses,
+            'categories' => $categories,
+            'locations' => $locations,
+            'units' => $units,
+            'usageStatuses' => $usage_statuses,
             'acquisitionMethods' => $acquisition_methods,
-            'name'               => $request->query('name'),
-            'category_id'        => $request->query('category_id'),
+            'name' => $request->query('name'),
+            'category_id' => $request->query('category_id'),
             'location_of_use_id' => $request->query('location_of_use_id'),
-            'manufacturer'       => $request->query('manufacturer'),
-            'price'              => $request->query('price'),
+            'manufacturer' => $request->query('manufacturer'),
+            'price' => $request->query('price'),
         ]);
     }
 
     public function store(StoreItemRequest $request)
     {
-        Log::info('ItemController store method called');
 
         // 編集理由はItemObserverのメソッド内でセッションから取得し、edithistoriesに保存
         Session::put('operation_type', 'store');
 
         // 変数の初期化
-        $fileNameToStore   = null;
-        $labelNameToStore  = null;
+        $fileNameToStore = null;
+        $labelNameToStore = null;
         $qrCodeNameToStore = null;
 
         DB::beginTransaction();
@@ -231,54 +227,54 @@ class ItemController extends Controller
             $management_id = $this->managementIdService->generate($request->category_id);
 
             $item = Item::create([
-                'management_id'         => $management_id,
-                'name'                  => $request->name,
-                'category_id'           => $request->category_id,
-                'stock'                 => $request->stock ?? 0,
-                'unit_id'               => $request->unit_id,
-                'minimum_stock'         => $minimum_stock,
-                'notification'          => $request->notification,
-                'usage_status_id'       => $request->usage_status_id,
-                'end_user'              => $request->end_user ?: null,
-                'location_of_use_id'    => $request->location_of_use_id,
-                'storage_location_id'   => $request->storage_location_id,
+                'management_id' => $management_id,
+                'name' => $request->name,
+                'category_id' => $request->category_id,
+                'stock' => $request->stock ?? 0,
+                'unit_id' => $request->unit_id,
+                'minimum_stock' => $minimum_stock,
+                'notification' => $request->notification,
+                'usage_status_id' => $request->usage_status_id,
+                'end_user' => $request->end_user ?: null,
+                'location_of_use_id' => $request->location_of_use_id,
+                'storage_location_id' => $request->storage_location_id,
                 'acquisition_method_id' => $request->acquisition_method_id,
-                'acquisition_source'    => $request->acquisition_source ?: null,
-                'price'                 => $request->price,
-                'date_of_acquisition'   => $request->date_of_acquisition,
-                'manufacturer'          => $request->manufacturer ?: null,
-                'product_number'        => $request->product_number ?: null,
-                'remarks'               => $request->remarks ?: null,
-                'qrcode'                => null,
+                'acquisition_source' => $request->acquisition_source ?: null,
+                'price' => $request->price,
+                'date_of_acquisition' => $request->date_of_acquisition,
+                'manufacturer' => $request->manufacturer ?: null,
+                'product_number' => $request->product_number ?: null,
+                'remarks' => $request->remarks ?: null,
+                'qrcode' => null,
             ]);
 
             if ($request->category_id == self::CATEGORY_ID_FOR_CONSUMABLE_ITME) {
                 StockTransaction::create([
-                    'item_id'          => $item->id,
+                    'item_id' => $item->id,
                     'transaction_type' => '登録',
-                    'quantity'         => $item->stock,
-                    'operator_name'    => Auth::user()->name,
+                    'quantity' => $item->stock,
+                    'operator_name' => Auth::user()->name,
                 ]);
             }
 
             if ($request->inspection_scheduled_date !== null) {
                 Inspection::create([
-                    'item_id'                   => $item->id,
+                    'item_id' => $item->id,
                     'inspection_scheduled_date' => $request->inspection_scheduled_date,
-                    'inspection_date'           => null,
-                    'status'                    => false, // 未実施がfalse
-                    'inspection_person'         => null,
-                    'details'                   => null,
+                    'inspection_date' => null,
+                    'status' => false, // 未実施がfalse
+                    'inspection_person' => null,
+                    'details' => null,
                 ]);
             }
 
             if ($request->disposal_scheduled_date !== null) {
                 Disposal::create([
-                    'item_id'                 => $item->id,
+                    'item_id' => $item->id,
                     'disposal_scheduled_date' => $request->disposal_scheduled_date,
-                    'disposal_date'           => null,
-                    'disposal_person'         => null,
-                    'details'                 => null,
+                    'disposal_date' => null,
+                    'disposal_person' => null,
+                    'details' => null,
                 ]);
             }
 
@@ -295,7 +291,7 @@ class ItemController extends Controller
             if ($request->category_id == self::CATEGORY_ID_FOR_CONSUMABLE_ITME) {
                 $result = $this->qrCodeService::upload($item);
                 // トランザクション処理失敗時のためにQRコード画像のファイル名を取得
-                $labelNameToStore  = $result['labelNameToStore'];
+                $labelNameToStore = $result['labelNameToStore'];
                 $qrCodeNameToStore = $result['qrCodeNameToStore'];
 
                 // 一時的にObserverを無効にする
@@ -306,36 +302,34 @@ class ItemController extends Controller
 
             DB::commit();
 
-            Log::info('ItemController store method succeeded');
-
             return to_route('items.index')
                 ->with([
                     'message' => '備品を登録しました',
-                    'status'  => 'success',
+                    'status' => 'success',
                 ]);
         } catch (\Exception $e) {
             DB::rollBack();
 
             Log::error('ItemController store method Transaction failed', [
-                'error'   => $e->getMessage(),
-                'stack'   => $e->getTraceAsString(),
+                'error' => $e->getMessage(),
+                'stack' => $e->getTraceAsString(),
                 'request' => $request->all(),
             ]);
 
             // アップロードした備品の画像の削除
-            $imagePath = 'items/' . $fileNameToStore;
+            $imagePath = 'items/'.$fileNameToStore;
             if (Storage::disk()->exists($imagePath)) {
                 Storage::disk()->delete($imagePath);
             }
 
             // qrCodeService内で保存したQRコードを削除
-            $qrImagePath = 'qrcode/' . $qrCodeNameToStore;
+            $qrImagePath = 'qrcode/'.$qrCodeNameToStore;
             if (Storage::disk()->exists($qrImagePath)) {
                 Storage::disk()->delete($qrImagePath);
             }
 
             // 保存したQRコードラベルを削除
-            $labelImagePath = 'labels/' . $labelNameToStore;
+            $labelImagePath = 'labels/'.$labelNameToStore;
             if (Storage::disk()->exists($labelImagePath)) {
                 Storage::disk()->delete($labelImagePath);
             }
@@ -343,17 +337,16 @@ class ItemController extends Controller
             return redirect()->back()
                 ->with([
                     'message' => '備品の登録中にエラーが発生しました',
-                    'status'  => 'danger',
+                    'status' => 'danger',
                 ]);
         }
     }
 
     public function show(Item $item)
     {
-        Log::info('ItemController show method called');
 
         $withRelations = ['category', 'unit', 'usageStatus', 'locationOfUse', 'storageLocation', 'acquisitionMethod', 'inspections', 'disposal'];
-        $item          = Item::with($withRelations)->find($item->id);
+        $item = Item::with($withRelations)->find($item->id);
 
         // まだ点検を実施していない点検テーブルのレコードを取得
         $uncompleted_inspection = $item->inspections->where('status', false)->sortBy('inspection_scheduled_date')->first();
@@ -365,55 +358,49 @@ class ItemController extends Controller
 
         $user = auth()->user();
 
-        Log::info('ItemController show method succeeded');
-
         return Inertia::render('Items/Show', [
-            'item'                      => $item,
-            'uncompleted_inspection'    => $uncompleted_inspection,
+            'item' => $item,
+            'uncompleted_inspection' => $uncompleted_inspection,
             'last_completed_inspection' => $last_completed_inspection,
-            'userName'                  => $user->name,
+            'userName' => $user->name,
         ]);
     }
 
     public function edit(Item $item)
     {
-        Log::info('ItemController edit method called');
 
         $withRelations = ['category', 'unit', 'usageStatus', 'locationOfUse', 'storageLocation', 'acquisitionMethod', 'inspections', 'disposal'];
-        $item          = Item::with($withRelations)->find($item->id);
+        $item = Item::with($withRelations)->find($item->id);
 
         // 未実行の点検予定日を取得
-        $uncompleted_inspection                = $item->inspections->where('status', false)->sortBy('inspection_scheduled_date')->first();
+        $uncompleted_inspection = $item->inspections->where('status', false)->sortBy('inspection_scheduled_date')->first();
         $uncompleted_inspection_scheduled_date = $uncompleted_inspection ? $uncompleted_inspection->inspection_scheduled_date : null;
 
         // 画像パスを追加
         $this->imageService->setImagePathToObject($item);
 
-        $categories          = Category::all();
-        $locations           = Location::all();
-        $units               = Unit::all();
-        $usage_statuses      = UsageStatus::all();
+        $categories = Category::all();
+        $locations = Location::all();
+        $units = Unit::all();
+        $usage_statuses = UsageStatus::all();
         $acquisition_methods = AcquisitionMethod::all();
-        $edit_reasons        = EditReason::all();
-
-        Log::info('ItemController edit method succeeded');
+        $edit_reasons = EditReason::all();
 
         return Inertia::render('Items/Edit', [
-            'item'                                  => $item,
+            'item' => $item,
             'uncompleted_inspection_scheduled_date' => $uncompleted_inspection_scheduled_date,
-            'categories'                            => $categories,
-            'locations'                             => $locations,
-            'units'                                 => $units,
-            'usageStatuses'                         => $usage_statuses,
-            'acquisitionMethods'                    => $acquisition_methods,
-            'editReasons'                           => $edit_reasons,
+            'categories' => $categories,
+            'locations' => $locations,
+            'units' => $units,
+            'usageStatuses' => $usage_statuses,
+            'acquisitionMethods' => $acquisition_methods,
+            'editReasons' => $edit_reasons,
         ]);
     }
 
     public function update(UpdateItemRequest $request, Item $item)
     {
         // トランザクション処理は、ItemObserverでのDB保存もロールバックする
-        Log::info('ItemController update method called');
 
         // ロールバックした時の備品画像を元に戻す準備
         if (! Storage::disk()->exists('temp')) {
@@ -426,11 +413,11 @@ class ItemController extends Controller
         Session::put('operation_type', 'update');
 
         // 変数の初期化
-        $fileNameToStore     = null;
-        $fileNameOfOldImage  = null;
+        $fileNameToStore = null;
+        $fileNameOfOldImage = null;
         $temporaryBackupPath = null;
-        $labelNameToStore    = null;
-        $qrCodeNameToStore   = null;
+        $labelNameToStore = null;
+        $qrCodeNameToStore = null;
 
         DB::beginTransaction();
 
@@ -440,35 +427,35 @@ class ItemController extends Controller
                 $item->stock != $request->stock
             ) {
                 StockTransaction::create([
-                    'item_id'          => $item->id,
+                    'item_id' => $item->id,
                     'transaction_type' => '修正',
-                    'quantity'         => $request->stock - $item->stock, //差分を保存
-                    'operator_name'    => Auth::user()->name,
+                    'quantity' => $request->stock - $item->stock, // 差分を保存
+                    'operator_name' => Auth::user()->name,
                 ]);
             }
 
-            $item->name        = $request->name;
+            $item->name = $request->name;
             $item->category_id = $request->category_id;
-            $item->stock       = $request->stock;
-            $item->unit_id     = $request->unit_id;
+            $item->stock = $request->stock;
+            $item->unit_id = $request->unit_id;
             // 消耗品の時だけminimum_stockを保存できる
             if ($request->category_id == self::CATEGORY_ID_FOR_CONSUMABLE_ITME) {
                 $item->minimum_stock = $request->minimum_stock;
             } else {
                 $item->minimum_stock = null;
             }
-            $item->notification          = $request->notification;
-            $item->usage_status_id       = $request->usage_status_id;
-            $item->end_user              = $request->end_user;
-            $item->location_of_use_id    = $request->location_of_use_id;
-            $item->storage_location_id   = $request->storage_location_id;
+            $item->notification = $request->notification;
+            $item->usage_status_id = $request->usage_status_id;
+            $item->end_user = $request->end_user;
+            $item->location_of_use_id = $request->location_of_use_id;
+            $item->storage_location_id = $request->storage_location_id;
             $item->acquisition_method_id = $request->acquisition_method_id;
-            $item->acquisition_source    = $request->acquisition_source;
-            $item->price                 = $request->price;
-            $item->date_of_acquisition   = $request->date_of_acquisition;
-            $item->manufacturer          = $request->manufacturer;
-            $item->product_number        = $request->product_number;
-            $item->remarks               = $request->remarks;
+            $item->acquisition_source = $request->acquisition_source;
+            $item->price = $request->price;
+            $item->date_of_acquisition = $request->date_of_acquisition;
+            $item->manufacturer = $request->manufacturer;
+            $item->product_number = $request->product_number;
+            $item->remarks = $request->remarks;
             $item->save();
 
             // 点検レコードの更新処理
@@ -502,10 +489,10 @@ class ItemController extends Controller
                 // すでに画像があれば削除
                 $fileNameOfOldImage = $item->image1;
                 if ($fileNameOfOldImage) {
-                    $temporaryBackupPath = 'temp/' . $fileNameOfOldImage;
+                    $temporaryBackupPath = 'temp/'.$fileNameOfOldImage;
                     // 一時的な退避フォルダ(temp)に変更前の画像をコピーでバックアップ
-                    Storage::disk()->copy('items/' . $fileNameOfOldImage, $temporaryBackupPath);
-                    Storage::disk()->delete('items/' . $fileNameOfOldImage);
+                    Storage::disk()->copy('items/'.$fileNameOfOldImage, $temporaryBackupPath);
+                    Storage::disk()->delete('items/'.$fileNameOfOldImage);
                 }
 
                 // 画像ファイルのアップロードとDBのimage1のファイル名更新
@@ -525,7 +512,7 @@ class ItemController extends Controller
 
                 $result = $this->qrCodeService::upload($item);
                 // トランザクション処理失敗時のためにQRコード画像のファイル名を取得
-                $labelNameToStore  = $result['labelNameToStore'];
+                $labelNameToStore = $result['labelNameToStore'];
                 $qrCodeNameToStore = $result['qrCodeNameToStore'];
 
                 $item->update(['qrcode' => $labelNameToStore]);
@@ -533,40 +520,38 @@ class ItemController extends Controller
 
             DB::commit();
 
-            Log::info('ItemController update method succeeded');
-
             return to_route('items.show', $item->id)
                 ->with([
                     'message' => '備品を更新しました',
-                    'status'  => 'success',
+                    'status' => 'success',
                 ]);
         } catch (\Exception $e) {
             DB::rollBack();
 
             Log::error('ItemController update method Transaction failed', [
-                'error'   => $e->getMessage(),
-                'stack'   => $e->getTraceAsString(),
+                'error' => $e->getMessage(),
+                'stack' => $e->getTraceAsString(),
                 'request' => $request->all(),
             ]);
 
             // アップロードしたプロフィール画像を削除
-            if (Storage::disk()->exists('items/' . $fileNameToStore)) {
-                Storage::disk()->delete('items/' . $fileNameToStore);
+            if (Storage::disk()->exists('items/'.$fileNameToStore)) {
+                Storage::disk()->delete('items/'.$fileNameToStore);
             }
 
             // バックアップした変更前の画像を元の場所に保存
             if ($temporaryBackupPath) {
-                Storage::disk()->move($temporaryBackupPath, 'items/' . $fileNameOfOldImage);
+                Storage::disk()->move($temporaryBackupPath, 'items/'.$fileNameOfOldImage);
             }
 
             // qrCodeService内で保存したQRコードを削除
-            $qrImagePath = 'qrcode/' . $qrCodeNameToStore;
+            $qrImagePath = 'qrcode/'.$qrCodeNameToStore;
             if (Storage::disk()->exists($qrImagePath)) {
                 Storage::disk()->delete($qrImagePath);
             }
 
             // 保存したQRコードラベルを削除
-            $labelImagePath = 'labels/' . $labelNameToStore;
+            $labelImagePath = 'labels/'.$labelNameToStore;
             if (Storage::disk()->exists($labelImagePath)) {
                 Storage::disk()->delete($labelImagePath);
             }
@@ -574,7 +559,7 @@ class ItemController extends Controller
             return redirect()->back()
                 ->with([
                     'message' => '登録中にエラーが発生しました',
-                    'status'  => 'danger',
+                    'status' => 'danger',
                 ]);
         } finally {
             // 成功しても失敗しても必ず行う処理

--- a/app/Http/Controllers/ItemRequestController.php
+++ b/app/Http/Controllers/ItemRequestController.php
@@ -3,7 +3,6 @@
 namespace App\Http\Controllers;
 
 use App\Events\RequestedItemDetectEvent;
-use App\Http\Controllers\Controller;
 use App\Http\Requests\StoreItemRequestRequest;
 use App\Models\Category;
 use App\Models\ItemRequest;
@@ -18,13 +17,12 @@ class ItemRequestController extends Controller
 {
     public function index(Request $request)
     {
-        Log::info('ItemRequestController index method called');
 
         // 作成日でソートの値、初期値はasc
         $sortOrder = $request->query('sortOrder', 'asc');
 
         $withRelations = ['category', 'locationOfUse', 'requestStatus'];
-        $selectFields  = [
+        $selectFields = [
             'id',
             'name',
             'category_id',
@@ -48,6 +46,7 @@ class ItemRequestController extends Controller
 
         $item_requests->getCollection()->transform(function ($item) {
             $item->formatted_created_at = $item->created_at->format('Y-m-d H:i:s');
+
             return $item;
         });
 
@@ -55,48 +54,42 @@ class ItemRequestController extends Controller
 
         $request_statuses = RequestStatus::all();
 
-        Log::info('ItemRequestController index method succeeded');
-
         return Inertia::render('ItemRequests/Index', [
-            'itemRequests'    => $item_requests,
-            'sortOrder'       => $sortOrder,
-            'totalCount'      => $total_count,
+            'itemRequests' => $item_requests,
+            'sortOrder' => $sortOrder,
+            'totalCount' => $total_count,
             'requestStatuses' => $request_statuses,
         ]);
     }
 
     public function create()
     {
-        Log::info('ItemRequestController create method called');
 
         $categories = Category::all();
-        $locations  = Location::all();
-
-        Log::info('ItemRequestController create method succeeded');
+        $locations = Location::all();
 
         return Inertia::render('ItemRequests/Create', [
             'categories' => $categories,
-            'locations'  => $locations,
+            'locations' => $locations,
         ]);
     }
 
     public function store(StoreItemRequestRequest $request)
     {
-        Log::info('ItemRequestController store method called');
 
         DB::beginTransaction();
 
         try {
             $itemRequest = ItemRequest::create([
-                'name'                   => $request->name,
-                'category_id'            => $request->category_id,
-                'location_of_use_id'     => $request->location_of_use_id,
-                'requestor'              => $request->requestor,
+                'name' => $request->name,
+                'category_id' => $request->category_id,
+                'location_of_use_id' => $request->location_of_use_id,
+                'requestor' => $request->requestor,
                 'remarks_from_requestor' => $request->remarks_from_requestor,
-                'request_status_id'      => 1,
-                'manufacturer'           => $request->manufacturer,
-                'reference'              => $request->reference,
-                'price'                  => $request->price,
+                'request_status_id' => 1,
+                'manufacturer' => $request->manufacturer,
+                'reference' => $request->reference,
+                'price' => $request->price,
             ]);
 
             // リクエストが作成されたらイベントを発火
@@ -104,42 +97,37 @@ class ItemRequestController extends Controller
 
             DB::commit();
 
-            Log::info('ItemRequestController store method succeeded');
-
             return to_route('item_requests.index')
                 ->with([
                     'message' => 'リクエストしました。',
-                    'status'  => 'success',
+                    'status' => 'success',
                 ]);
         } catch (\Exception $e) {
             DB::rollBack();
 
             Log::error('ItemRequestController store method Transaction failed', [
-                'error'   => $e->getMessage(),
-                'stack'   => $e->getTraceAsString(),
+                'error' => $e->getMessage(),
+                'stack' => $e->getTraceAsString(),
                 'request' => $request->all(),
             ]);
 
             return redirect()->back()
                 ->with([
                     'message' => '登録中にエラーが発生しました',
-                    'status'  => 'danger',
+                    'status' => 'danger',
                 ]);
         }
     }
 
     public function destroy(ItemRequest $itemRequest)
     {
-        Log::info('ItemRequestController destroy method called');
 
         $itemRequest->delete();
-
-        Log::info('ItemRequestController destroy method succeeded');
 
         return to_route('item_requests.index')
             ->with([
                 'message' => 'リクエストを削除しました',
-                'status'  => 'danger',
+                'status' => 'danger',
             ]);
     }
 }

--- a/app/Http/Controllers/NotificationController.php
+++ b/app/Http/Controllers/NotificationController.php
@@ -2,25 +2,21 @@
 
 namespace App\Http\Controllers;
 
-use App\Http\Controllers\Controller;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\Log;
 use Inertia\Inertia;
 
 class NotificationController extends Controller
 {
     public function index()
     {
-        Log::info('NotificationController index method called');
-
         // Auth::user()->notifications; ログイン中ユーザーへの通知
         // SystemNotification::all(); 全ての通知
         // ※情報がない場合、nullではなく空のコレクションとして扱われる
 
         // ログイン中のユーザーに向けた通知を取得
         $notifications = Auth::user()->notifications->map(function ($notification) {
-            $notification->id            = (string) $notification->id;                                // UUIDを文字列として扱う、明示的に文字列としないと挙動がおかしくなる
+            $notification->id = (string) $notification->id;                                // UUIDを文字列として扱う、明示的に文字列としないと挙動がおかしくなる
             $notification->relative_time = Carbon::parse($notification->created_at)->diffForHumans(); // 相対的な時間を追加
 
             return $notification;
@@ -53,20 +49,18 @@ class NotificationController extends Controller
         })->take(20);
 
         // タブの右上に表示する丸の判定基準のため、それぞれの未読の通知数を所得
-        $unreadLowStockNotifications              = $lowStockNotifications->where('read_at', null)->count();
+        $unreadLowStockNotifications = $lowStockNotifications->where('read_at', null)->count();
         $unreadInspectionAndDisposalNotifications = $inspectionAndDisposalNotifications->where('read_at', null)->count();
-        $unreadRequestedItemNotifications         = $requestedItemNotifications->where('read_at', null)->count();
-
-        Log::info('NotificationController index method succeeded');
+        $unreadRequestedItemNotifications = $requestedItemNotifications->where('read_at', null)->count();
 
         return Inertia::render('Notification', [
-            'notifications'                            => $notifications,
-            'lowStockNotifications'                    => $lowStockNotifications,
-            'inspectionAndDisposalNotifications'       => $inspectionAndDisposalNotifications,
-            'requestedItemNotifications'               => $requestedItemNotifications,
-            'unreadLowStockNotifications'              => $unreadLowStockNotifications,
+            'notifications' => $notifications,
+            'lowStockNotifications' => $lowStockNotifications,
+            'inspectionAndDisposalNotifications' => $inspectionAndDisposalNotifications,
+            'requestedItemNotifications' => $requestedItemNotifications,
+            'unreadLowStockNotifications' => $unreadLowStockNotifications,
             'unreadInspectionAndDisposalNotifications' => $unreadInspectionAndDisposalNotifications,
-            'unreadRequestedItemNotifications'         => $unreadRequestedItemNotifications,
+            'unreadRequestedItemNotifications' => $unreadRequestedItemNotifications,
         ]);
     }
 }

--- a/app/Http/Controllers/PDFController.php
+++ b/app/Http/Controllers/PDFController.php
@@ -2,7 +2,6 @@
 
 namespace App\Http\Controllers;
 
-use App\Http\Controllers\Controller;
 use App\Models\Item;
 use Barryvdh\Snappy\Facades\SnappyPdf as PDF;
 use Illuminate\Support\Facades\Log;
@@ -14,8 +13,6 @@ class PDFController extends Controller
 
     public function generatePDF()
     {
-        Log::info('PDFController generatePDF method called');
-
         // 消耗品のQRコードをすべて取得する（現在カテゴリが消耗品のもの、変更されている可能性もある）
         $consumableItems = Item::whereNull('deleted_at')
             ->where('category_id', self::CATEGORY_ID_FOR_CONSUMABLE_ITME)
@@ -25,8 +22,8 @@ class PDFController extends Controller
         $qrCodes = [];
         foreach ($consumableItems as $consumableItem) {
             $qrCodes[] = config('filesystems.default') === 's3'
-                ? Storage::disk()->url('labels/' . $consumableItem->qrcode)
-                : Storage::disk()->path('labels/' . $consumableItem->qrcode);
+                ? Storage::disk()->url('labels/'.$consumableItem->qrcode)
+                : Storage::disk()->path('labels/'.$consumableItem->qrcode);
         }
 
         if (empty($qrCodes)) {
@@ -35,7 +32,7 @@ class PDFController extends Controller
             return to_route('consumable_items')
                 ->with([
                     'message' => 'QRラベルが存在しません',
-                    'status'  => 'danger',
+                    'status' => 'danger',
                 ]);
         }
 
@@ -49,8 +46,6 @@ class PDFController extends Controller
             ->setOption('footer-center', '[page] / [topage]') // フッター中央に現在のページ番号と総ページ数を表示
             ->setOption('footer-font-size', 10)
             ->setOption('enable-local-file-access', true);
-
-        Log::info('PDFController generatePDF method succeeded');
 
         return $pdf->inline('消耗品QRコード.pdf');
     }

--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -26,9 +26,8 @@ class ProfileController extends Controller
 
     public function edit(Request $request): Response
     {
-        Log::info('ProfileController edit method called');
 
-        $user          = Auth::user();
+        $user = Auth::user();
         $profile_image = $user->profile_image;
 
         $defaultDisk = Storage::disk();
@@ -36,25 +35,22 @@ class ProfileController extends Controller
         if (is_null($profile_image)) {
             $profile_image_path = $defaultDisk->url('profile/profile_default_image.png');
         } else {
-            if (Storage::disk()->exists('profile/' . $profile_image)) {
-                $profile_image_path = $defaultDisk->url('profile/' . $profile_image);
+            if (Storage::disk()->exists('profile/'.$profile_image)) {
+                $profile_image_path = $defaultDisk->url('profile/'.$profile_image);
             } else {
                 $profile_image_path = $defaultDisk->url('profile/profile_default_image.png');
             }
         }
 
-        Log::info('ProfileController edit method succeeded');
-
         return Inertia::render('Profile/Edit', [
-            'mustVerifyEmail'    => $request->user() instanceof MustVerifyEmail,
-            'status'             => session('status'),
+            'mustVerifyEmail' => $request->user() instanceof MustVerifyEmail,
+            'status' => session('status'),
             'profile_image_path' => $profile_image_path,
         ]);
     }
 
     public function update(ProfileUpdateRequest $request): RedirectResponse
     {
-        Log::info('ProfileController update method called');
 
         // ロールバックした時のプロフィール画像を元に戻す準備
         if (! Storage::disk()->exists('temp')) {
@@ -63,8 +59,8 @@ class ProfileController extends Controller
 
         // 変数の初期化
         $profileImagefileNameToStore = null;
-        $fileNameOfOldProfileImage   = null;
-        $temporaryBackupPath         = null;
+        $fileNameOfOldProfileImage = null;
+        $temporaryBackupPath = null;
 
         DB::beginTransaction();
 
@@ -79,13 +75,13 @@ class ProfileController extends Controller
                 // すでに画像があれば削除
                 $fileNameOfOldProfileImage = $request->user()->profile_image;
                 if ($fileNameOfOldProfileImage) {
-                    $temporaryBackupPath = 'temp/' . $fileNameOfOldProfileImage;
-                    Storage::disk()->copy('items/' . $fileNameOfOldProfileImage, $temporaryBackupPath);
-                    Storage::disk()->delete('profile/' . $request->user()->profile_image);
+                    $temporaryBackupPath = 'temp/'.$fileNameOfOldProfileImage;
+                    Storage::disk()->copy('items/'.$fileNameOfOldProfileImage, $temporaryBackupPath);
+                    Storage::disk()->delete('profile/'.$request->user()->profile_image);
                 }
 
                 // 画像ファイルのアップロードとDBのimage1のファイル名更新
-                $profileImagefileNameToStore    = $this->imageService->profileImageResizeUpload($request->profile_image_file);
+                $profileImagefileNameToStore = $this->imageService->profileImageResizeUpload($request->profile_image_file);
                 $request->user()->profile_image = $profileImagefileNameToStore;
             }
 
@@ -93,36 +89,34 @@ class ProfileController extends Controller
 
             DB::commit();
 
-            Log::info('ProfileController update method succeeded');
-
             return Redirect::route('profile.edit')
                 ->with([
                     'message' => 'プロフィールを更新しました。',
-                    'status'  => 'success',
+                    'status' => 'success',
                 ]);
         } catch (\Exception $e) {
             DB::rollBack();
 
             Log::error('ProfileController update method Transaction failed', [
-                'error'   => $e->getMessage(),
-                'stack'   => $e->getTraceAsString(),
+                'error' => $e->getMessage(),
+                'stack' => $e->getTraceAsString(),
                 'request' => $request->all(),
             ]);
 
             // アップロードした備品の画像の削除
-            if (Storage::disk()->exists('profile/' . $profileImagefileNameToStore)) {
-                Storage::disk()->delete('profile/' . $profileImagefileNameToStore);
+            if (Storage::disk()->exists('profile/'.$profileImagefileNameToStore)) {
+                Storage::disk()->delete('profile/'.$profileImagefileNameToStore);
             }
 
             // バックアップした変更前のプロフィール画像を元の場所に保存
             if ($temporaryBackupPath) {
-                Storage::disk()->move($temporaryBackupPath, 'items/' . $fileNameOfOldProfileImage);
+                Storage::disk()->move($temporaryBackupPath, 'items/'.$fileNameOfOldProfileImage);
             }
 
             return redirect()->back()
                 ->with([
                     'message' => 'プロフィールの更新中にエラーが発生しました',
-                    'status'  => 'danger',
+                    'status' => 'danger',
                 ]);
         }
     }

--- a/app/Http/Controllers/UpdateStockController.php
+++ b/app/Http/Controllers/UpdateStockController.php
@@ -3,7 +3,6 @@
 namespace App\Http\Controllers;
 
 use App\Events\LowStockDetectEvent;
-use App\Http\Controllers\Controller;
 use App\Http\Requests\DecreaseStockRequest;
 use App\Http\Requests\IncreaseStockRequest;
 use App\Models\Item;
@@ -15,7 +14,6 @@ class UpdateStockController extends Controller
 {
     public function decreaseStock(DecreaseStockRequest $request, Item $item)
     {
-        Log::info('UpdateStockController decreaseStock method called');
 
         DB::beginTransaction();
 
@@ -27,15 +25,15 @@ class UpdateStockController extends Controller
                 return to_route('consumable_items')
                     ->with([
                         'message' => '出庫数に正しい値を入力してください',
-                        'status' => 'danger'
+                        'status' => 'danger',
                     ]);
             }
 
             // stock_transactionsテーブルの新しいレコードを作成
-            $stockTransaction = new StockTransaction();
+            $stockTransaction = new StockTransaction;
             $stockTransaction->item_id = $item->id;
             $stockTransaction->transaction_type = $request->transaction_type;
-            $stockTransaction->quantity = -$request->quantity; //出庫なので数量をマイナスにして保存
+            $stockTransaction->quantity = -$request->quantity; // 出庫なので数量をマイナスにして保存
             $stockTransaction->operator_name = $request->operator_name;
             $stockTransaction->save();
 
@@ -52,12 +50,10 @@ class UpdateStockController extends Controller
 
             DB::commit();
 
-            Log::info('UpdateStockController decreaseStock method succeeded');
-
             return to_route('consumable_items')
                 ->with([
                     'message' => '在庫数を更新しました。',
-                    'status' => 'success'
+                    'status' => 'success',
                 ]);
         } catch (\Exception $e) {
             DB::rollBack();
@@ -65,20 +61,19 @@ class UpdateStockController extends Controller
             Log::error('UpdateStockController decreaseStock method Transaction failed', [
                 'error' => $e->getMessage(),
                 'stack' => $e->getTraceAsString(),
-                'request' => $request->all()
+                'request' => $request->all(),
             ]);
 
             return redirect()->back()
                 ->with([
                     'message' => '登録中にエラーが発生しました',
-                    'status' => 'danger'
+                    'status' => 'danger',
                 ]);
         }
     }
 
     public function increaseStock(IncreaseStockRequest $request, Item $item)
     {
-        Log::info('UpdateStockController increaseStock method called');
 
         DB::beginTransaction();
 
@@ -90,11 +85,11 @@ class UpdateStockController extends Controller
                 return to_route('consumable_items')
                     ->with([
                         'message' => '出庫数に正しい値を入力してください',
-                        'status' => 'danger'
+                        'status' => 'danger',
                     ]);
             }
 
-            $stockTransaction = new StockTransaction();
+            $stockTransaction = new StockTransaction;
             $stockTransaction->item_id = $item->id;
             $stockTransaction->transaction_type = $request->transaction_type;
             $stockTransaction->quantity = $request->quantity;
@@ -109,12 +104,10 @@ class UpdateStockController extends Controller
 
             DB::commit();
 
-            Log::info('UpdateStockController increaseStock method succeeded');
-
             return to_route('consumable_items')
                 ->with([
                     'message' => '在庫数を更新しました。',
-                    'status' => 'success'
+                    'status' => 'success',
                 ]);
         } catch (\Exception $e) {
             DB::rollBack();
@@ -122,13 +115,13 @@ class UpdateStockController extends Controller
             Log::error('UpdateStockController increaseStock method Transaction failed', [
                 'error' => $e->getMessage(),
                 'stack' => $e->getTraceAsString(),
-                'request' => $request->all()
+                'request' => $request->all(),
             ]);
 
             return redirect()->back()
                 ->with([
                     'message' => '登録中にエラーが発生しました',
-                    'status' => 'danger'
+                    'status' => 'danger',
                 ]);
         }
     }


### PR DESCRIPTION
## 概要
Controller の各メソッドに手書きしていた、正常系の
`Log::info('... called')` / `('... succeeded')` を削除しました。

## 背景
これらのログは冗長であることが調査で判明しました。

- **「呼ばれた・成功した」** は Apache のアクセスログが既に記録している
  （`GET /items 200` など）
- **呼び出し元のクラス名・メソッド名・行番号** は、
  `App\Logging\CustomizeFormatter` に設定した Monolog の
  `IntrospectionProcessor` が自動で付与している

つまりメッセージに手書きしていた情報は、いずれも別の仕組みで
記録済みでした。ノイズを減らすことで、本当に見たいログ
（エラー・警告）の視認性を上げるのが狙いです。

## 変更内容
- Controller / Service の正常系 `Log::info` を削除

## 対象外
- **バッチ（Command）のログ** … 削除しない
  - `app:inspection-schedule` / `app:disposal-schedule`
  - Web と異なりアクセスログで代替できず、実行有無・処理件数の
    記録が必要なため

## 動作確認
- 既存テストが緑のままであることを確認

Closes #594