### PR TITLE
Refactor/item index

### DIFF
--- a/app/Http/Controllers/ItemController.php
+++ b/app/Http/Controllers/ItemController.php
@@ -101,16 +101,9 @@ class ItemController extends Controller
             $query = $query->with($withRelations)
                 ->searchItems($search)
                 ->filterByCategory($category_id)
+                ->filterByLocationOfUse($location_of_use_id)
                 ->select($selectFields)
                 ->orderBy('created_at', $sortOrder);
-
-            // if (Category::where('id', $category_id)->exists()) {
-            //     $query->where('category_id', $category_id);
-            // }
-
-            if (Location::where('id', $location_of_use_id)->exists()) {
-                $query->where('location_of_use_id', $location_of_use_id);
-            }
 
             if (Location::where('id', $storage_location_id)->exists()) {
                 $query->where('storage_location_id', $storage_location_id);

--- a/app/Http/Controllers/ItemController.php
+++ b/app/Http/Controllers/ItemController.php
@@ -100,14 +100,13 @@ class ItemController extends Controller
             // withによるeagerローディングではリレーションを使用する
             $query = $query->with($withRelations)
                 ->searchItems($search)
+                ->filterByCategory($category_id)
                 ->select($selectFields)
                 ->orderBy('created_at', $sortOrder);
 
-            // DBに設定されているidの時のみ反映
-            // 各プルダウン変更時のクエリ、ローカルスコープに切り出しリファクタリング
-            if (Category::where('id', $category_id)->exists()) {
-                $query->where('category_id', $category_id);
-            }
+            // if (Category::where('id', $category_id)->exists()) {
+            //     $query->where('category_id', $category_id);
+            // }
 
             if (Location::where('id', $location_of_use_id)->exists()) {
                 $query->where('location_of_use_id', $location_of_use_id);

--- a/app/Http/Controllers/ItemController.php
+++ b/app/Http/Controllers/ItemController.php
@@ -120,14 +120,10 @@ class ItemController extends Controller
         // 変換後のコレクションを元のpaginateオブジェクトに戻す
         $items = $items->setCollection($items->getCollection());
 
-        // プルダウン用データ
-        $categories = Category::all();
-        $locations = Location::all();
-
         return Inertia::render('Items/Index', [
             'items' => $items,
-            'categories' => $categories,
-            'locations' => $locations,
+            'categories' => Category::all(), // 今後キャッシュ実装予定
+            'locations' => Location::all(), // 今後キャッシュ実装予定
             'search' => $search,
             'sortOrder' => $sortOrder,
             'categoryId' => $category_id,
@@ -138,7 +134,6 @@ class ItemController extends Controller
             'endNumber' => $items->lastItem() ?? 0,
             'disposal' => $disposal,
         ]);
-
     }
 
     public function create(Request $request)

--- a/app/Http/Controllers/ItemController.php
+++ b/app/Http/Controllers/ItemController.php
@@ -50,121 +50,106 @@ class ItemController extends Controller
 
     public function index(Request $request)
     {
+        $search = (string) $request->query('search', '');
 
-        try {
-            $search = (string) $request->query('search', '');
+        $sortOrder = $request->query('sortOrder') === 'asc' ? 'asc' : 'desc';
 
-            $sortOrder = $request->query('sortOrder') === 'asc' ? 'asc' : 'desc';
+        $category_id = (int) $request->query('categoryId', 0);
+        $location_of_use_id = (int) $request->query('locationOfUseId', 0);
+        $storage_location_id = (int) $request->query('storageLocationId', 0);
+        $disposal = $request->query('disposal', 'false');
 
-            // プルダウンの数値、第2引数は初期値で0
-            $category_id = (int) $request->query('categoryId', 0);
-            $location_of_use_id = (int) $request->query('locationOfUseId', 0);
-            $storage_location_id = (int) $request->query('storageLocationId', 0);
-            $disposal = $request->query('disposal', 'false');
+        $withRelations = ['category', 'unit', 'usageStatus', 'locationOfUse', 'storageLocation', 'acquisitionMethod', 'inspections', 'disposal'];
+        $selectFields = [
+            'id',
+            'management_id',
+            'name',
+            'category_id',
+            'image1',
+            'stock',
+            'unit_id',
+            'minimum_stock',
+            'notification',
+            'usage_status_id',
+            'end_user',
+            'location_of_use_id',
+            'storage_location_id',
+            'acquisition_method_id',
+            'acquisition_source',
+            'price',
+            'date_of_acquisition',
+            'manufacturer',
+            'product_number',
+            'remarks',
+            'qrcode',
+            'deleted_at',
+            'created_at',
+        ];
 
-            $withRelations = ['category', 'unit', 'usageStatus', 'locationOfUse', 'storageLocation', 'acquisitionMethod', 'inspections', 'disposal'];
-            $selectFields = [
-                'id',
-                'management_id',
-                'name',
-                'category_id',
-                'image1',
-                'stock',
-                'unit_id',
-                'minimum_stock',
-                'notification',
-                'usage_status_id',
-                'end_user',
-                'location_of_use_id',
-                'storage_location_id',
-                'acquisition_method_id',
-                'acquisition_source',
-                'price',
-                'date_of_acquisition',
-                'manufacturer',
-                'product_number',
-                'remarks',
-                'qrcode',
-                'deleted_at',
-                'created_at',
-            ];
-
-            // 通常の備品か廃棄済みの備品かの分岐
-            if ($disposal === 'true') {
-                $query = Item::onlyTrashed();
-            } else {
-                $query = Item::whereNull('deleted_at');
-            }
-
-            // withによるeagerローディングではリレーションを使用する
-            $query = $query->with($withRelations)
-                ->searchItems($search)
-                ->filterByCategory($category_id)
-                ->filterByLocationOfUse($location_of_use_id)
-                ->filterByStorageLocation($storage_location_id)
-                ->select($selectFields)
-                ->orderBy('created_at', $sortOrder);
-
-            $total_count = $query->count();
-            $items = $query->paginate(20);
-
-            $current_page = $items->currentPage(); // 現在のページ番号
-            $per_page = $items->perPage();     // 1ページあたりの項目数
-            if ($total_count !== 0) {
-                $start_number = ($current_page - 1) * $per_page + 1;                    // 現在のページの最初の項目番号
-                $end_number = min($start_number + $items->count() - 1, $total_count); // 現在のページの最後の項目番号
-            } else {
-                $start_number = 0;
-                $end_number = 0;
-            }
-
-            // map関数を使用するとpaginateオブジェクトの構造が変わり、ペジネーションが使えなくなる
-            $items->getCollection()->transform(function ($item) {
-                return $this->imageService->setImagePathToObject($item);
-            });
-
-            $items->getCollection()->transform(function ($item) {
-                // inspection_scheduled_dateを追加
-                $inspection = $item->inspections->where('status', false)->sortBy('inspection_scheduled_date')->first();
-                $item->inspection_scheduled_date = $inspection ? $inspection->inspection_scheduled_date : null;
-
-                return $item;
-            });
-
-            // 変換後のコレクションを元のpaginateオブジェクトに戻す
-            $items = $items->setCollection($items->getCollection());
-
-            // プルダウン用データ
-            $categories = Category::all();
-            $locations = Location::all();
-
-            return Inertia::render('Items/Index', [
-                'items' => $items,
-                'categories' => $categories,
-                'locations' => $locations,
-                'search' => $search,
-                'sortOrder' => $sortOrder,
-                'categoryId' => $category_id,
-                'locationOfUseId' => $location_of_use_id,
-                'storageLocationId' => $storage_location_id,
-                'totalCount' => $total_count,
-                'startNumber' => $start_number,
-                'endNumber' => $end_number,
-                'disposal' => $disposal,
-            ]);
-        } catch (\Exception $e) {
-            Log::error('ItemController index method failed', [
-                'error' => $e->getMessage(),
-                'stack' => $e->getTraceAsString(),
-                'request' => $request->all(),
-            ]);
-
-            return redirect()->back()
-                ->with([
-                    'message' => '予期しないエラーが発生しました',
-                    'status' => 'danger',
-                ]);
+        // 通常の備品か廃棄済みの備品かの分岐
+        if ($disposal === 'true') {
+            $query = Item::onlyTrashed();
+        } else {
+            $query = Item::whereNull('deleted_at');
         }
+
+        // withによるeagerローディングではリレーションを使用する
+        $query = $query->with($withRelations)
+            ->searchItems($search)
+            ->filterByCategory($category_id)
+            ->filterByLocationOfUse($location_of_use_id)
+            ->filterByStorageLocation($storage_location_id)
+            ->select($selectFields)
+            ->orderBy('created_at', $sortOrder);
+
+        $total_count = $query->count();
+        $items = $query->paginate(20);
+
+        $current_page = $items->currentPage(); // 現在のページ番号
+        $per_page = $items->perPage();     // 1ページあたりの項目数
+        if ($total_count !== 0) {
+            $start_number = ($current_page - 1) * $per_page + 1;                    // 現在のページの最初の項目番号
+            $end_number = min($start_number + $items->count() - 1, $total_count); // 現在のページの最後の項目番号
+        } else {
+            $start_number = 0;
+            $end_number = 0;
+        }
+
+        // map関数を使用するとpaginateオブジェクトの構造が変わり、ペジネーションが使えなくなる
+        $items->getCollection()->transform(function ($item) {
+            return $this->imageService->setImagePathToObject($item);
+        });
+
+        $items->getCollection()->transform(function ($item) {
+            // inspection_scheduled_dateを追加
+            $inspection = $item->inspections->where('status', false)->sortBy('inspection_scheduled_date')->first();
+            $item->inspection_scheduled_date = $inspection ? $inspection->inspection_scheduled_date : null;
+
+            return $item;
+        });
+
+        // 変換後のコレクションを元のpaginateオブジェクトに戻す
+        $items = $items->setCollection($items->getCollection());
+
+        // プルダウン用データ
+        $categories = Category::all();
+        $locations = Location::all();
+
+        return Inertia::render('Items/Index', [
+            'items' => $items,
+            'categories' => $categories,
+            'locations' => $locations,
+            'search' => $search,
+            'sortOrder' => $sortOrder,
+            'categoryId' => $category_id,
+            'locationOfUseId' => $location_of_use_id,
+            'storageLocationId' => $storage_location_id,
+            'totalCount' => $total_count,
+            'startNumber' => $start_number,
+            'endNumber' => $end_number,
+            'disposal' => $disposal,
+        ]);
+
     }
 
     public function create(Request $request)

--- a/app/Http/Controllers/ItemController.php
+++ b/app/Http/Controllers/ItemController.php
@@ -102,12 +102,9 @@ class ItemController extends Controller
                 ->searchItems($search)
                 ->filterByCategory($category_id)
                 ->filterByLocationOfUse($location_of_use_id)
+                ->filterByStorageLocation($storage_location_id)
                 ->select($selectFields)
                 ->orderBy('created_at', $sortOrder);
-
-            if (Location::where('id', $storage_location_id)->exists()) {
-                $query->where('storage_location_id', $storage_location_id);
-            }
 
             $total_count = $query->count();
             $items = $query->paginate(20);

--- a/app/Http/Controllers/ItemController.php
+++ b/app/Http/Controllers/ItemController.php
@@ -102,18 +102,7 @@ class ItemController extends Controller
             ->select($selectFields)
             ->orderBy('created_at', $sortOrder);
 
-        $total_count = $query->count();
         $items = $query->paginate(20);
-
-        $current_page = $items->currentPage(); // 現在のページ番号
-        $per_page = $items->perPage();     // 1ページあたりの項目数
-        if ($total_count !== 0) {
-            $start_number = ($current_page - 1) * $per_page + 1;                    // 現在のページの最初の項目番号
-            $end_number = min($start_number + $items->count() - 1, $total_count); // 現在のページの最後の項目番号
-        } else {
-            $start_number = 0;
-            $end_number = 0;
-        }
 
         // map関数を使用するとpaginateオブジェクトの構造が変わり、ペジネーションが使えなくなる
         $items->getCollection()->transform(function ($item) {
@@ -144,9 +133,9 @@ class ItemController extends Controller
             'categoryId' => $category_id,
             'locationOfUseId' => $location_of_use_id,
             'storageLocationId' => $storage_location_id,
-            'totalCount' => $total_count,
-            'startNumber' => $start_number,
-            'endNumber' => $end_number,
+            'totalCount' => $items->total(),
+            'startNumber' => $items->firstItem() ?? 0,
+            'endNumber' => $items->lastItem() ?? 0,
             'disposal' => $disposal,
         ]);
 

--- a/app/Http/Controllers/ItemController.php
+++ b/app/Http/Controllers/ItemController.php
@@ -52,15 +52,14 @@ class ItemController extends Controller
     {
 
         try {
-            $search = $request->query('search', '');
+            $search = (string) $request->query('search', '');
 
-            // 作成日でソートの値、初期値はasc
-            $sortOrder = $request->query('sortOrder', 'desc');
+            $sortOrder = $request->query('sortOrder') === 'asc' ? 'asc' : 'desc';
 
             // プルダウンの数値、第2引数は初期値で0
-            $category_id = $request->query('categoryId', 0);
-            $location_of_use_id = $request->query('locationOfUseId', 0);
-            $storage_location_id = $request->query('storageLocationId', 0);
+            $category_id = (int) $request->query('categoryId', 0);
+            $location_of_use_id = (int) $request->query('locationOfUseId', 0);
+            $storage_location_id = (int) $request->query('storageLocationId', 0);
             $disposal = $request->query('disposal', 'false');
 
             $withRelations = ['category', 'unit', 'usageStatus', 'locationOfUse', 'storageLocation', 'acquisitionMethod', 'inspections', 'disposal'];

--- a/app/Models/Item.php
+++ b/app/Models/Item.php
@@ -125,6 +125,14 @@ class Item extends Model
         );
     }
 
+    public function scopeFilterByLocationOfUse(Builder $query, ?string $locationId)
+    {
+        return $query->when(
+            $locationId && Location::whereKey($locationId)->exists(),
+            fn ($q) => $q->where('location_of_use_id', $locationId)
+        );
+    }
+
     // createad_atを'Y-m-d'形式にするアクセサ
     public function getCreatedAtAttribute($value)
     {

--- a/app/Models/Item.php
+++ b/app/Models/Item.php
@@ -133,6 +133,14 @@ class Item extends Model
         );
     }
 
+    public function scopeFilterByStorageLocation(Builder $query, ?string $locationId)
+    {
+        return $query->when(
+            $locationId && Location::whereKey($locationId)->exists(),
+            fn ($q) => $q->where('storage_location_id', $locationId)
+        );
+    }
+
     // createad_atを'Y-m-d'形式にするアクセサ
     public function getCreatedAtAttribute($value)
     {

--- a/app/Models/Item.php
+++ b/app/Models/Item.php
@@ -2,11 +2,8 @@
 
 namespace App\Models;
 
-use App\Models\Category;
-use App\Models\Disposal;
-use App\Models\Location;
-use App\Models\Unit;
 use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -118,6 +115,14 @@ class Item extends Model
         if (! empty($input)) {
             return $query->where('name', 'like', "%{$input}%");
         }
+    }
+
+    public function scopeFilterByCategory(Builder $query, ?string $categoryId)
+    {
+        return $query->when(
+            $categoryId && Category::whereKey($categoryId)->exists(),
+            fn ($q) => $q->where('category_id', $categoryId)
+        );
     }
 
     // createad_atを'Y-m-d'形式にするアクセサ

--- a/tests/Feature/Http/Controllers/ItemController/Index/IndexMethodTest.php
+++ b/tests/Feature/Http/Controllers/ItemController/Index/IndexMethodTest.php
@@ -33,102 +33,95 @@ class IndexMethodTest extends TestCase
     /** @test */
     public function 備品一覧画面表示用のpaginateオブジェクトのデータを渡す()
     {
+        // Arrange Act Assert を明示する
+
         // リレーションのダミーデータを作成
         // $categories = Category::all(); all()は使えない
-        $categories         = Category::factory()->count(11)->create();
-        $units              = Unit::factory()->count(10)->create();
-        $usage_statuses     = UsageStatus::factory()->count(2)->create();
-        $locations          = Location::factory()->count(12)->create();
+        $categories = Category::factory()->count(11)->create();
+        $units = Unit::factory()->count(10)->create();
+        $usage_statuses = UsageStatus::factory()->count(2)->create();
+        $locations = Location::factory()->count(12)->create();
         $aquisition_methods = AcquisitionMethod::factory()->count(6)->create();
 
-        // 各コレクションの要素数を出力
-        echo 'Categories count: ' . $categories->count() . PHP_EOL;
-        echo 'Units count: ' . $units->count() . PHP_EOL;
-        echo 'Usage Statuses count: ' . $usage_statuses->count() . PHP_EOL;
-        echo 'Locations count: ' . $locations->count() . PHP_EOL;
-        echo 'Acquisition Methods count: ' . $aquisition_methods->count() . PHP_EOL;
-
         $items = Item::factory()->count(20)->create([
-            'management_id'         => $this->faker->regexify('[A-Za-z0-9]{7}'),
+            'management_id' => $this->faker->regexify('[A-Za-z0-9]{7}'),
             // 'name' => 'テストアイテム', // nameを上書きできる
-            'category_id'           => $categories->random()->id,
-            'unit_id'               => $units->random()->id,
-            'usage_status_id'       => $usage_statuses->random()->id,
-            'location_of_use_id'    => $locations->random()->id,
-            'storage_location_id'   => $locations->random()->id,
+            'category_id' => $categories->random()->id,
+            'unit_id' => $units->random()->id,
+            'usage_status_id' => $usage_statuses->random()->id,
+            'location_of_use_id' => $locations->random()->id,
+            'storage_location_id' => $locations->random()->id,
             'acquisition_method_id' => $aquisition_methods->random()->id,
-            'deleted_at'            => null, //ソフトデリートされていない
+            'deleted_at' => null, // ソフトデリートされていない
         ]);
 
-        // adminユーザーを作成
-        $user = User::factory()->role(1)->create();
-        $this->actingAs($user);
+        // adminユーザーでログイン
+        $this->actingAs(User::factory()->role(1)->create());
 
         $response = $this->get('/items')
             ->assertOk();
-        \Log::info('レスポンス: ' . $response->status()); // レスポンスのステータスコードをログに出力
 
-        $response->assertInertia(fn(Assert $page) => $page
-                ->component('Items/Index')
-                ->has('items.data', 20)
-                ->has('items.data', fn($data) => $data
-                        ->each(fn($item) => $item
-                                ->hasAll([
-                                    'id',
-                                    'management_id',
-                                    'name',
-                                    'category_id',
-                                    'image1',
-                                    'stock',
-                                    'unit_id',
-                                    'minimum_stock',
-                                    'notification',
-                                    'usage_status_id',
-                                    'end_user',
-                                    'location_of_use_id',
-                                    'storage_location_id',
-                                    'acquisition_method_id',
-                                    'acquisition_source',
-                                    'price',
-                                    'date_of_acquisition',
-                                    'manufacturer',
-                                    'product_number',
-                                    'remarks',
-                                    'qrcode',
-                                    'deleted_at',
-                                    'created_at',
-                                    'image_path1', //画像名から加工した画像パス
-                                    'inspection_scheduled_date',
-                                    'category',
-                                    'unit',
-                                    'usage_status',
-                                    'location_of_use',
-                                    'storage_location',
-                                    'acquisition_method',
-                                    'inspections',
-                                    'disposal',
-                                ])
-                                ->has('category', fn($category) => $category
-                                        ->hasAll(['id', 'name', 'created_at', 'updated_at'])
-                                )
-                                ->has('unit', fn($unit) => $unit
-                                        ->hasAll(['id', 'name', 'created_at', 'updated_at'])
-                                )
-                                ->has('location_of_use', fn($location) => $location
-                                        ->hasAll(['id', 'name', 'created_at', 'updated_at'])
-                                )
-                                ->has('storage_location', fn($location) => $location
-                                        ->hasAll(['id', 'name', 'created_at', 'updated_at'])
-                                )
-                                ->has('acquisition_method', fn($acquisition_method) => $acquisition_method
-                                        ->hasAll(['id', 'name', 'created_at', 'updated_at'])
-                                )
-                                ->has('usage_status', fn($usage_status) => $usage_status
-                                        ->hasAll(['id', 'name', 'created_at', 'updated_at'])
-                                )
+        $response->assertInertia(fn (Assert $page) => $page
+            ->component('Items/Index')
+            ->has('items.data', 20)
+            ->has('items.data', fn ($data) => $data
+                ->each(fn ($item) => $item
+                    ->hasAll([
+                        'id',
+                        'management_id',
+                        'name',
+                        'category_id',
+                        'image1',
+                        'stock',
+                        'unit_id',
+                        'minimum_stock',
+                        'notification',
+                        'usage_status_id',
+                        'end_user',
+                        'location_of_use_id',
+                        'storage_location_id',
+                        'acquisition_method_id',
+                        'acquisition_source',
+                        'price',
+                        'date_of_acquisition',
+                        'manufacturer',
+                        'product_number',
+                        'remarks',
+                        'qrcode',
+                        'deleted_at',
+                        'created_at',
+                        'image_path1', // 画像名から加工した画像パス
+                        'inspection_scheduled_date',
+                        'category',
+                        'unit',
+                        'usage_status',
+                        'location_of_use',
+                        'storage_location',
+                        'acquisition_method',
+                        'inspections',
+                        'disposal',
+                    ])
+                    ->has('category', fn ($category) => $category
+                        ->hasAll(['id', 'name', 'created_at', 'updated_at'])
+                    )
+                    ->has('unit', fn ($unit) => $unit
+                        ->hasAll(['id', 'name', 'created_at', 'updated_at'])
+                    )
+                    ->has('location_of_use', fn ($location) => $location
+                        ->hasAll(['id', 'name', 'created_at', 'updated_at'])
+                    )
+                    ->has('storage_location', fn ($location) => $location
+                        ->hasAll(['id', 'name', 'created_at', 'updated_at'])
+                    )
+                    ->has('acquisition_method', fn ($acquisition_method) => $acquisition_method
+                        ->hasAll(['id', 'name', 'created_at', 'updated_at'])
+                    )
+                    ->has('usage_status', fn ($usage_status) => $usage_status
+                        ->hasAll(['id', 'name', 'created_at', 'updated_at'])
+                    )
 
-                        )
                 )
+            )
         );
     }
 
@@ -137,100 +130,164 @@ class IndexMethodTest extends TestCase
     {
         // リレーションのダミーデータを作成
         // $categories = Category::all(); all()は使えない
-        $categories         = Category::factory()->count(11)->create();
-        $units              = Unit::factory()->count(10)->create();
-        $usage_statuses     = UsageStatus::factory()->count(2)->create();
-        $locations          = Location::factory()->count(12)->create();
+        $categories = Category::factory()->count(11)->create();
+        $units = Unit::factory()->count(10)->create();
+        $usage_statuses = UsageStatus::factory()->count(2)->create();
+        $locations = Location::factory()->count(12)->create();
         $aquisition_methods = AcquisitionMethod::factory()->count(6)->create();
 
-        // 各コレクションの要素数を出力
-        echo 'Categories count: ' . $categories->count() . PHP_EOL;
-        echo 'Units count: ' . $units->count() . PHP_EOL;
-        echo 'Usage Statuses count: ' . $usage_statuses->count() . PHP_EOL;
-        echo 'Locations count: ' . $locations->count() . PHP_EOL;
-        echo 'Acquisition Methods count: ' . $aquisition_methods->count() . PHP_EOL;
-
         $items = Item::factory()->count(20)->create([
-            'management_id'         => $this->faker->regexify('[A-Za-z0-9]{7}'),
+            'management_id' => $this->faker->regexify('[A-Za-z0-9]{7}'),
             // 'name' => 'テストアイテム', // nameを上書きできる
-            'category_id'           => $categories->random()->id,
-            'unit_id'               => $units->random()->id,
-            'usage_status_id'       => $usage_statuses->random()->id,
-            'location_of_use_id'    => $locations->random()->id,
-            'storage_location_id'   => $locations->random()->id,
+            'category_id' => $categories->random()->id,
+            'unit_id' => $units->random()->id,
+            'usage_status_id' => $usage_statuses->random()->id,
+            'location_of_use_id' => $locations->random()->id,
+            'storage_location_id' => $locations->random()->id,
             'acquisition_method_id' => $aquisition_methods->random()->id,
-            'deleted_at'            => $this->faker->date(), //ソフトデリートされた（廃棄された）
+            'deleted_at' => $this->faker->date(), // ソフトデリートされた（廃棄された）
         ]);
 
-        // adminユーザーを作成
-        $user = User::factory()->role(1)->create();
-        $this->actingAs($user);
+        // adminユーザーでログイン
+        $this->actingAs(User::factory()->role(1)->create());
 
         $response = $this->get('/items?disposal=true')
             ->assertOk();
-        \Log::info('レスポンス: ' . $response->status()); // レスポンスのステータスコードをログに出力
 
-        $response->assertInertia(fn(Assert $page) => $page
-                ->component('Items/Index')
-                ->has('items.data', 20)
-                ->has('items.data', fn($data) => $data
-                        ->each(fn($item) => $item
-                                ->hasAll([
-                                    'id',
-                                    'management_id',
-                                    'name',
-                                    'category_id',
-                                    'image1',
-                                    'stock',
-                                    'unit_id',
-                                    'minimum_stock',
-                                    'notification',
-                                    'usage_status_id',
-                                    'end_user',
-                                    'location_of_use_id',
-                                    'storage_location_id',
-                                    'acquisition_method_id',
-                                    'acquisition_source',
-                                    'price',
-                                    'date_of_acquisition',
-                                    'manufacturer',
-                                    'product_number',
-                                    'remarks',
-                                    'qrcode',
-                                    'deleted_at',
-                                    'created_at',
-                                    'image_path1', //画像名から加工した画像パス
-                                    'inspection_scheduled_date',
-                                    'category',
-                                    'unit',
-                                    'usage_status',
-                                    'location_of_use',
-                                    'storage_location',
-                                    'acquisition_method',
-                                    'inspections',
-                                    'disposal',
-                                ])
-                                ->where('deleted_at', fn($deletedAt) => (bool) strtotime($deletedAt)) // `deleted_at` が有効な日付であることを確認
-                                ->has('category', fn($category) => $category
-                                        ->hasAll(['id', 'name', 'created_at', 'updated_at'])
-                                )
-                                ->has('unit', fn($unit) => $unit
-                                        ->hasAll(['id', 'name', 'created_at', 'updated_at'])
-                                )
-                                ->has('location_of_use', fn($location) => $location
-                                        ->hasAll(['id', 'name', 'created_at', 'updated_at'])
-                                )
-                                ->has('storage_location', fn($location) => $location
-                                        ->hasAll(['id', 'name', 'created_at', 'updated_at'])
-                                )
-                                ->has('acquisition_method', fn($acquisition_method) => $acquisition_method
-                                        ->hasAll(['id', 'name', 'created_at', 'updated_at'])
-                                )
-                                ->has('usage_status', fn($usage_status) => $usage_status
-                                        ->hasAll(['id', 'name', 'created_at', 'updated_at'])
-                                )
-                        )
+        $response->assertInertia(fn (Assert $page) => $page
+            ->component('Items/Index')
+            ->has('items.data', 20)
+            ->has('items.data', fn ($data) => $data
+                ->each(fn ($item) => $item
+                    ->hasAll([
+                        'id',
+                        'management_id',
+                        'name',
+                        'category_id',
+                        'image1',
+                        'stock',
+                        'unit_id',
+                        'minimum_stock',
+                        'notification',
+                        'usage_status_id',
+                        'end_user',
+                        'location_of_use_id',
+                        'storage_location_id',
+                        'acquisition_method_id',
+                        'acquisition_source',
+                        'price',
+                        'date_of_acquisition',
+                        'manufacturer',
+                        'product_number',
+                        'remarks',
+                        'qrcode',
+                        'deleted_at',
+                        'created_at',
+                        'image_path1', // 画像名から加工した画像パス
+                        'inspection_scheduled_date',
+                        'category',
+                        'unit',
+                        'usage_status',
+                        'location_of_use',
+                        'storage_location',
+                        'acquisition_method',
+                        'inspections',
+                        'disposal',
+                    ])
+                    ->where('deleted_at', fn ($deletedAt) => (bool) strtotime($deletedAt)) // `deleted_at` が有効な日付であることを確認
+                    ->has('category', fn ($category) => $category
+                        ->hasAll(['id', 'name', 'created_at', 'updated_at'])
+                    )
+                    ->has('unit', fn ($unit) => $unit
+                        ->hasAll(['id', 'name', 'created_at', 'updated_at'])
+                    )
+                    ->has('location_of_use', fn ($location) => $location
+                        ->hasAll(['id', 'name', 'created_at', 'updated_at'])
+                    )
+                    ->has('storage_location', fn ($location) => $location
+                        ->hasAll(['id', 'name', 'created_at', 'updated_at'])
+                    )
+                    ->has('acquisition_method', fn ($acquisition_method) => $acquisition_method
+                        ->hasAll(['id', 'name', 'created_at', 'updated_at'])
+                    )
+                    ->has('usage_status', fn ($usage_status) => $usage_status
+                        ->hasAll(['id', 'name', 'created_at', 'updated_at'])
+                    )
                 )
+            )
         );
+    }
+
+    /** @test */
+    public function category_idで備品を絞り込める(): void
+    {
+        // マスタとユーザーの準備...
+
+        $targetCategory = Category::factory()->create();
+        $otherCategory = Category::factory()->create();
+
+        $units = Unit::factory()->count(10)->create();
+        $usage_statuses = UsageStatus::factory()->count(2)->create();
+        $locations = Location::factory()->count(12)->create();
+        $aquisition_methods = AcquisitionMethod::factory()->count(6)->create();
+
+        Item::factory()->count(3)->create([
+            'management_id' => $this->faker->regexify('[A-Za-z0-9]{7}'),
+            'category_id' => $targetCategory->id,
+            'unit_id' => $units->random()->id,
+            'usage_status_id' => $usage_statuses->random()->id,
+            'location_of_use_id' => $locations->random()->id,
+            'storage_location_id' => $locations->random()->id,
+            'acquisition_method_id' => $aquisition_methods->random()->id,
+            'deleted_at' => null,
+        ]);
+
+        Item::factory()->count(2)->create([
+            'management_id' => $this->faker->regexify('[A-Za-z0-9]{7}'),
+            'category_id' => $otherCategory->id,
+            'unit_id' => $units->random()->id,
+            'usage_status_id' => $usage_statuses->random()->id,
+            'location_of_use_id' => $locations->random()->id,
+            'storage_location_id' => $locations->random()->id,
+            'acquisition_method_id' => $aquisition_methods->random()->id,
+            'deleted_at' => null,
+        ]);
+
+        $this->actingAs(User::factory()->role(1)->create());
+
+        $this->get("/items?categoryId={$targetCategory->id}")
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->has('items.data', 3)   // 対象カテゴリの3件だけ
+            );
+    }
+
+    /** @test */
+    public function 存在しないcategory_idでは絞り込まれず全件返る(): void
+    {
+        $categories = Category::factory()->count(11)->create();
+        $units = Unit::factory()->count(10)->create();
+        $usage_statuses = UsageStatus::factory()->count(2)->create();
+        $locations = Location::factory()->count(12)->create();
+        $aquisition_methods = AcquisitionMethod::factory()->count(6)->create();
+
+        $items = Item::factory()->count(5)->create([
+            'management_id' => $this->faker->regexify('[A-Za-z0-9]{7}'),
+            'category_id' => $categories->random()->id,
+            'unit_id' => $units->random()->id,
+            'usage_status_id' => $usage_statuses->random()->id,
+            'location_of_use_id' => $locations->random()->id,
+            'storage_location_id' => $locations->random()->id,
+            'acquisition_method_id' => $aquisition_methods->random()->id,
+            'deleted_at' => null, // ソフトデリートされていない
+        ]);
+
+        $this->actingAs(User::factory()->role(1)->create());
+
+        $this->get('/items?categoryId=99999')
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->has('items.data', 5)   // 現状は全件返る
+            );
     }
 }

--- a/tests/Feature/Http/Controllers/ItemController/Index/IndexMethodTest.php
+++ b/tests/Feature/Http/Controllers/ItemController/Index/IndexMethodTest.php
@@ -12,6 +12,8 @@ use App\Models\User;
 use Faker\Factory as FakerFactory;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Inertia\Testing\AssertableInertia as Assert;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
 class IndexMethodTest extends TestCase
@@ -430,6 +432,88 @@ class IndexMethodTest extends TestCase
             ->assertOk()
             ->assertInertia(fn (Assert $page) => $page
                 ->has('items.data', 5)   // 現状は全件返る
+            );
+    }
+
+    #[Test]
+    #[DataProvider('arrayParamProvider')]
+    public function プルダウンidに配列を渡しても500にならず全件返る(string $param): void
+    {
+        $categories = Category::factory()->count(11)->create();
+        $units = Unit::factory()->count(10)->create();
+        $usage_statuses = UsageStatus::factory()->count(2)->create();
+        $locations = Location::factory()->count(12)->create();
+        $aquisition_methods = AcquisitionMethod::factory()->count(6)->create();
+
+        $items = Item::factory()->count(5)->create([
+            'management_id' => $this->faker->regexify('[A-Za-z0-9]{7}'),
+            'category_id' => $categories->random()->id,
+            'unit_id' => $units->random()->id,
+            'usage_status_id' => $usage_statuses->random()->id,
+            'location_of_use_id' => $locations->random()->id,
+            'storage_location_id' => $locations->random()->id,
+            'acquisition_method_id' => $aquisition_methods->random()->id,
+            'deleted_at' => null, // ソフトデリートされていない
+        ]);
+
+        // adminユーザーでログイン
+        $this->actingAs(User::factory()->role(1)->create());
+
+        $this->get("/items?{$param}[]=1&{$param}[]=2")
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page->has('items.data', 5));
+    }
+
+    public static function arrayParamProvider(): array
+    {
+        return [
+            'category' => ['categoryId'],
+            'location_of_use' => ['locationOfUseId'],
+            'storage_location' => ['storageLocationId'],
+        ];
+    }
+
+    #[Test]
+    public function sort_orderに不正な値を渡してもエラーにならず新しい順で返る(): void
+    {
+        $categories = Category::factory()->count(11)->create();
+        $units = Unit::factory()->count(10)->create();
+        $usage_statuses = UsageStatus::factory()->count(2)->create();
+        $locations = Location::factory()->count(12)->create();
+        $aquisition_methods = AcquisitionMethod::factory()->count(6)->create();
+
+        // 作成日の異なる2件。desc なら new が先頭に来るはず
+        $old = Item::factory()->create([
+            'management_id' => $this->faker->regexify('[A-Za-z0-9]{7}'),
+            'category_id' => $categories->random()->id,
+            'unit_id' => $units->random()->id,
+            'usage_status_id' => $usage_statuses->random()->id,
+            'location_of_use_id' => $locations->random()->id,
+            'storage_location_id' => $locations->random()->id,
+            'acquisition_method_id' => $aquisition_methods->random()->id,
+            'deleted_at' => null,
+            'created_at' => now()->subDays(2),
+        ]);
+
+        $new = Item::factory()->create([
+            'management_id' => $this->faker->regexify('[A-Za-z0-9]{7}'),
+            'category_id' => $categories->random()->id,
+            'unit_id' => $units->random()->id,
+            'usage_status_id' => $usage_statuses->random()->id,
+            'location_of_use_id' => $locations->random()->id,
+            'storage_location_id' => $locations->random()->id,
+            'acquisition_method_id' => $aquisition_methods->random()->id,
+            'deleted_at' => null,
+            'created_at' => now(),
+        ]);
+
+        $this->actingAs(User::factory()->role(1)->create());
+
+        $this->get('/items?sortOrder=invalid')
+            ->assertOk()                       // 500 にならない
+            ->assertInertia(fn (Assert $page) => $page
+                ->has('items.data', 2)
+                ->where('items.data.0.id', $new->id)   // 先頭が新しい方 = desc に倒れた証拠
             );
     }
 }

--- a/tests/Feature/Http/Controllers/ItemController/Index/IndexMethodTest.php
+++ b/tests/Feature/Http/Controllers/ItemController/Index/IndexMethodTest.php
@@ -516,4 +516,82 @@ class IndexMethodTest extends TestCase
                 ->where('items.data.0.id', $new->id)   // 先頭が新しい方 = desc に倒れた証拠
             );
     }
+
+    #[Test]
+    public function ページ番号が正しく計算される_1ページ目(): void
+    {
+        $categories = Category::factory()->count(11)->create();
+        $units = Unit::factory()->count(10)->create();
+        $usage_statuses = UsageStatus::factory()->count(2)->create();
+        $locations = Location::factory()->count(12)->create();
+        $aquisition_methods = AcquisitionMethod::factory()->count(6)->create();
+
+        // 25件作る（1ページ20件なので、1ページ目は20件）
+        Item::factory()->count(25)->create([
+            'management_id' => $this->faker->regexify('[A-Za-z0-9]{7}'),
+            'category_id' => $categories->random()->id,
+            'unit_id' => $units->random()->id,
+            'usage_status_id' => $usage_statuses->random()->id,
+            'location_of_use_id' => $locations->random()->id,
+            'storage_location_id' => $locations->random()->id,
+            'acquisition_method_id' => $aquisition_methods->random()->id,
+            'deleted_at' => null,
+        ]);
+
+        $this->actingAs(User::factory()->role(1)->create());
+
+        $this->get('/items')
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->where('totalCount', 25)
+                ->where('startNumber', 1)
+                ->where('endNumber', 20)
+            );
+    }
+
+    #[Test]
+    public function ページ番号が正しく計算される_2ページ目(): void
+    {
+        $categories = Category::factory()->count(11)->create();
+        $units = Unit::factory()->count(10)->create();
+        $usage_statuses = UsageStatus::factory()->count(2)->create();
+        $locations = Location::factory()->count(12)->create();
+        $aquisition_methods = AcquisitionMethod::factory()->count(6)->create();
+
+        // 25件（2ページ目は 21〜25 の5件）
+        Item::factory()->count(25)->create([
+            'management_id' => $this->faker->regexify('[A-Za-z0-9]{7}'),
+            'category_id' => $categories->random()->id,
+            'unit_id' => $units->random()->id,
+            'usage_status_id' => $usage_statuses->random()->id,
+            'location_of_use_id' => $locations->random()->id,
+            'storage_location_id' => $locations->random()->id,
+            'acquisition_method_id' => $aquisition_methods->random()->id,
+            'deleted_at' => null,
+        ]);
+
+        $this->actingAs(User::factory()->role(1)->create());
+
+        $this->get('/items?page=2')
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->where('totalCount', 25)
+                ->where('startNumber', 21)
+                ->where('endNumber', 25)   // 半端な最終ページ = min() が効く境界
+            );
+    }
+
+    #[Test]
+    public function 備品が0件のときページ番号は0になる(): void
+    {
+        $this->actingAs(User::factory()->role(1)->create());
+
+        $this->get('/items')
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->where('totalCount', 0)
+                ->where('startNumber', 0)
+                ->where('endNumber', 0)
+            );
+    }
 }

--- a/tests/Feature/Http/Controllers/ItemController/Index/IndexMethodTest.php
+++ b/tests/Feature/Http/Controllers/ItemController/Index/IndexMethodTest.php
@@ -360,4 +360,76 @@ class IndexMethodTest extends TestCase
                 ->has('items.data', 5)   // 現状は全件返る
             );
     }
+
+    /** @test */
+    public function storage_location_idで備品を絞り込める(): void
+    {
+        $categories = Category::factory()->count(11)->create();
+        $units = Unit::factory()->count(10)->create();
+        $usage_statuses = UsageStatus::factory()->count(2)->create();
+
+        $targetLocation = Location::factory()->create();
+        $otherLocation = Location::factory()->create();
+
+        $aquisition_methods = AcquisitionMethod::factory()->count(6)->create();
+
+        Item::factory()->count(3)->create([
+            'management_id' => $this->faker->regexify('[A-Za-z0-9]{7}'),
+            'category_id' => $categories->random()->id,
+            'unit_id' => $units->random()->id,
+            'usage_status_id' => $usage_statuses->random()->id,
+            'location_of_use_id' => $otherLocation->id,      // わざと別のを入れる
+            'storage_location_id' => $targetLocation->id,    // 絞り込み対象
+            'acquisition_method_id' => $aquisition_methods->random()->id,
+            'deleted_at' => null,
+        ]);
+
+        Item::factory()->count(2)->create([
+            'management_id' => $this->faker->regexify('[A-Za-z0-9]{7}'),
+            'category_id' => $categories->random()->id,
+            'unit_id' => $units->random()->id,
+            'usage_status_id' => $usage_statuses->random()->id,
+            'location_of_use_id' => $otherLocation->id,
+            'storage_location_id' => $otherLocation->id,
+            'acquisition_method_id' => $aquisition_methods->random()->id,
+            'deleted_at' => null,
+        ]);
+
+        $this->actingAs(User::factory()->role(1)->create());
+
+        $this->get("/items?storageLocationId={$targetLocation->id}")
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->has('items.data', 3)   // 保管場所が対象の3件だけ
+            );
+    }
+
+    /** @test */
+    public function 存在しないstorage_location_idでは絞り込まれず全件返る(): void
+    {
+        $categories = Category::factory()->count(11)->create();
+        $units = Unit::factory()->count(10)->create();
+        $usage_statuses = UsageStatus::factory()->count(2)->create();
+        $locations = Location::factory()->count(12)->create();
+        $aquisition_methods = AcquisitionMethod::factory()->count(6)->create();
+
+        Item::factory()->count(5)->create([
+            'management_id' => $this->faker->regexify('[A-Za-z0-9]{7}'),
+            'category_id' => $categories->random()->id,
+            'unit_id' => $units->random()->id,
+            'usage_status_id' => $usage_statuses->random()->id,
+            'location_of_use_id' => $locations->random()->id,
+            'storage_location_id' => $locations->random()->id,
+            'acquisition_method_id' => $aquisition_methods->random()->id,
+            'deleted_at' => null,
+        ]);
+
+        $this->actingAs(User::factory()->role(1)->create());
+
+        $this->get('/items?storageLocationId=99999')
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->has('items.data', 5)   // 現状は全件返る
+            );
+    }
 }

--- a/tests/Feature/Http/Controllers/ItemController/Index/IndexMethodTest.php
+++ b/tests/Feature/Http/Controllers/ItemController/Index/IndexMethodTest.php
@@ -221,8 +221,6 @@ class IndexMethodTest extends TestCase
     /** @test */
     public function category_idで備品を絞り込める(): void
     {
-        // マスタとユーザーの準備...
-
         $targetCategory = Category::factory()->create();
         $otherCategory = Category::factory()->create();
 
@@ -285,6 +283,78 @@ class IndexMethodTest extends TestCase
         $this->actingAs(User::factory()->role(1)->create());
 
         $this->get('/items?categoryId=99999')
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->has('items.data', 5)   // 現状は全件返る
+            );
+    }
+
+    /** @test */
+    public function location_of_use_idで備品を絞り込める(): void
+    {
+        $categories = Category::factory()->count(11)->create();
+        $units = Unit::factory()->count(10)->create();
+        $usage_statuses = UsageStatus::factory()->count(2)->create();
+
+        $targetLocation = Location::factory()->create();
+        $otherLocation = Location::factory()->create();
+
+        $aquisition_methods = AcquisitionMethod::factory()->count(6)->create();
+
+        Item::factory()->count(3)->create([
+            'management_id' => $this->faker->regexify('[A-Za-z0-9]{7}'),
+            'category_id' => $categories->random()->id,
+            'unit_id' => $units->random()->id,
+            'usage_status_id' => $usage_statuses->random()->id,
+            'location_of_use_id' => $targetLocation->id,
+            'storage_location_id' => $otherLocation->id,
+            'acquisition_method_id' => $aquisition_methods->random()->id,
+            'deleted_at' => null,
+        ]);
+
+        Item::factory()->count(2)->create([
+            'management_id' => $this->faker->regexify('[A-Za-z0-9]{7}'),
+            'category_id' => $categories->random()->id,
+            'unit_id' => $units->random()->id,
+            'usage_status_id' => $usage_statuses->random()->id,
+            'location_of_use_id' => $otherLocation->id,
+            'storage_location_id' => $otherLocation->id,
+            'acquisition_method_id' => $aquisition_methods->random()->id,
+            'deleted_at' => null,
+        ]);
+
+        $this->actingAs(User::factory()->role(1)->create());
+
+        $this->get("/items?locationOfUseId={$targetLocation->id}")
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->has('items.data', 3)   // 使用場所が対象の3件だけ
+            );
+    }
+
+    /** @test */
+    public function 存在しないlocation_of_use_idでは絞り込まれず全件返る(): void
+    {
+        $categories = Category::factory()->count(11)->create();
+        $units = Unit::factory()->count(10)->create();
+        $usage_statuses = UsageStatus::factory()->count(2)->create();
+        $locations = Location::factory()->count(12)->create();
+        $aquisition_methods = AcquisitionMethod::factory()->count(6)->create();
+
+        Item::factory()->count(5)->create([
+            'management_id' => $this->faker->regexify('[A-Za-z0-9]{7}'),
+            'category_id' => $categories->random()->id,
+            'unit_id' => $units->random()->id,
+            'usage_status_id' => $usage_statuses->random()->id,
+            'location_of_use_id' => $locations->random()->id,
+            'storage_location_id' => $locations->random()->id,
+            'acquisition_method_id' => $aquisition_methods->random()->id,
+            'deleted_at' => null,
+        ]);
+
+        $this->actingAs(User::factory()->role(1)->create());
+
+        $this->get('/items?locationOfUseId=99999')
             ->assertOk()
             ->assertInertia(fn (Assert $page) => $page
                 ->has('items.data', 5)   // 現状は全件返る


### PR DESCRIPTION
## 概要
ItemController@index の Fat Controller を段階的に整理した。

- 絞り込み（category/location/storage）を Item のクエリスコープへ
- 入力値を型ごとに正規化（int キャスト / sortOrder ホワイトリスト）
- ページ番号計算を paginator の標準メソッド（firstItem/lastItem/total）へ
- 例外を握りつぶす try/catch を削除し、フレームワークの例外ハンドラに委譲
- プルダウン用データの一時変数をインライン化

各変更はテストで現状の振る舞いを固定してから実施。全テスト緑。

Closes #596